### PR TITLE
Gameplay UX: Add Start/Pause and soft Restart flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import * as THREE from 'three';
 import GameScene from './components/GameScene';
 import HUD from './components/HUD';
 import { dofSettings } from './components/CinematicCamera';
+import useGameStore from './store/gameStore';
 import './index.css';
 
 /**
@@ -40,6 +41,7 @@ function DynamicDepthOfField() {
 
 function App() {
   const [dpr, setDpr] = useState(1.5);
+  const gameState = useGameStore((state) => state.gameState);
 
   return (
     <>
@@ -53,7 +55,7 @@ function App() {
         >
           <color attach="background" args={['#050510']} />
           <Suspense fallback={null}>
-            <Physics>
+            <Physics paused={gameState !== 'playing'}>
               <GameScene />
             </Physics>
           </Suspense>

--- a/src/components/Asteroid.tsx
+++ b/src/components/Asteroid.tsx
@@ -118,11 +118,7 @@ export default function Asteroid({ id, startPos, type, active, onDestroy }: Aste
         }
 
         const gameState = useGameStore.getState().gameState;
-        if (gameState === 'gameover') {
-            rbRef.current.setLinvel({ x: 0, y: 0, z: 0 }, true);
-            rbRef.current.setAngvel({ x: 0, y: 0, z: 0 }, true);
-            return;
-        }
+        if (gameState !== 'playing') return;
 
         // Hit flash logic
         if (entityRef.current.health! < prevHealthRef.current) {

--- a/src/components/AsteroidField.tsx
+++ b/src/components/AsteroidField.tsx
@@ -166,7 +166,7 @@ export default function AsteroidField({ onDestroy }: AsteroidFieldProps) {
     }
 
     const gameState = useGameStore.getState().gameState;
-    if (gameState !== 'gameover') {
+    if (gameState === 'playing') {
       for (let i = runtimesRef.current.length - 1; i >= 0; i--) {
         const runtime = runtimesRef.current[i];
         if (!runtime) continue;

--- a/src/components/AsteroidSpawner.tsx
+++ b/src/components/AsteroidSpawner.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
@@ -18,9 +18,15 @@ export default function AsteroidSpawner() {
     const spawnTimer = useRef(0);
     // Base spawn interval in seconds
     const currentInterval = useRef(2.0);
+    const sessionId = useGameStore((state) => state.sessionId);
+
+    useEffect(() => {
+        spawnTimer.current = 0;
+        currentInterval.current = 2.0;
+    }, [sessionId]);
 
     useFrame((_, delta) => {
-        if (useGameStore.getState().gameState === 'gameover') return;
+        if (useGameStore.getState().gameState !== 'playing') return;
         spawnTimer.current += delta;
 
         if (spawnTimer.current >= currentInterval.current) {

--- a/src/components/GameScene.tsx
+++ b/src/components/GameScene.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import CinematicCamera from './CinematicCamera';
 import SpaceBackground from './SpaceBackground';
@@ -10,7 +10,7 @@ import Asteroid from './Asteroid';
 import AsteroidSpawner from './AsteroidSpawner';
 import Explosion from './Explosion';
 import { v4 as uuidv4 } from 'uuid';
-import { drainAsteroidSpawns } from '../ecs/asteroidSpawnQueue';
+import { clearAsteroidSpawns, drainAsteroidSpawns } from '../ecs/asteroidSpawnQueue';
 
 interface PooledAsteroid {
     id: string;
@@ -55,7 +55,51 @@ export default function GameScene() {
 
     const [shieldImpacts, setShieldImpacts] = useState<ShieldImpactData[]>([]);
 
-    const { incrementDestroyed, setActiveAsteroids } = useGameStore();
+    const explosionsRef = useRef<PooledExplosion[]>([]);
+
+    const incrementDestroyed = useGameStore((state) => state.incrementDestroyed);
+    const setActiveAsteroids = useGameStore((state) => state.setActiveAsteroids);
+    const sessionId = useGameStore((state) => state.sessionId);
+
+    useEffect(() => {
+        explosionsRef.current = explosions;
+    }, [explosions]);
+
+    const clearExplosionTimers = useCallback((pool: PooledExplosion[]) => {
+        for (const explosion of pool) {
+            if (explosion.timer) {
+                clearTimeout(explosion.timer);
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            clearExplosionTimers(explosionsRef.current);
+        };
+    }, [clearExplosionTimers]);
+
+    useEffect(() => {
+        clearAsteroidSpawns();
+        setShieldImpacts([]);
+        setAsteroids((prev) => prev.map((ast) => ({
+            ...ast,
+            active: false,
+            pos: [0, -1000, 0],
+        })));
+        setExplosions((prev) => prev.map((exp) => {
+            if (exp.timer) {
+                clearTimeout(exp.timer);
+            }
+            return {
+                ...exp,
+                active: false,
+                pos: [0, -1000, 0],
+                timer: undefined,
+            };
+        }));
+        setActiveAsteroids(0);
+    }, [sessionId, setActiveAsteroids]);
 
     const triggerExplosion = useCallback((pos: [number, number, number], type: AsteroidType) => {
         setExplosions(prev => {
@@ -81,6 +125,8 @@ export default function GameScene() {
     }, []);
 
     useFrame(() => {
+        if (useGameStore.getState().gameState !== 'playing') return;
+
         const spawns = drainAsteroidSpawns();
         if (spawns.length > 0) {
             setAsteroids(prev => {

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -9,9 +9,30 @@ export default function HUD() {
     const health = useGameStore((state) => state.health);
     const maxHealth = useGameStore((state) => state.maxHealth);
     const gameState = useGameStore((state) => state.gameState);
+    const startGame = useGameStore((state) => state.startGame);
+    const togglePause = useGameStore((state) => state.togglePause);
+    const resumeGame = useGameStore((state) => state.resumeGame);
+    const restartGame = useGameStore((state) => state.restartGame);
     const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
++    // trigger a brief visual pulse when the game state changes
++    const [badgePulse, setBadgePulse] = useState(false);
 
-    const healthPercent = (health / maxHealth) * 100;
+    const healthPercent = maxHealth > 0 ? (health / maxHealth) * 100 : 0;
+
+    const stateBadge = {
+        menu: { label: 'MENU', bg: 'rgba(59,130,246,0.24)', border: 'rgba(96,165,250,0.65)', color: '#bfdbfe' },
+        playing: { label: 'PLAYING', bg: 'rgba(34,197,94,0.2)', border: 'rgba(74,222,128,0.6)', color: '#dcfce7' },
+        paused: { label: 'PAUSED', bg: 'rgba(245,158,11,0.2)', border: 'rgba(251,191,36,0.65)', color: '#fef3c7' },
+        gameover: { label: 'GAME OVER', bg: 'rgba(239,68,68,0.2)', border: 'rgba(248,113,113,0.6)', color: '#fee2e2' },
+    }[gameState];
++
++    // animate badge on state transitions
++    useEffect(() => {
++        // pulse the badge then clear after animation duration
++        setBadgePulse(true);
++        const t = setTimeout(() => setBadgePulse(false), 200);
++        return () => clearTimeout(t);
++    }, [gameState]);
 
     useEffect(() => {
         try {
@@ -23,6 +44,23 @@ export default function HUD() {
             // If storage is unavailable, default to showing onboarding for accessibility.
             setIsOnboardingOpen(true);
         }
+    }, []);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape' || event.repeat) return;
+
+            const state = useGameStore.getState();
+            if (state.gameState === 'playing' || state.gameState === 'paused') {
+                event.preventDefault();
+                state.togglePause();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
     }, []);
 
     const dismissOnboarding = () => {
@@ -51,7 +89,32 @@ export default function HUD() {
                 gap: '8px',
                 textShadow: '0 2px 4px rgba(0,0,0,0.8)'
             }}>
-                <h1 style={{ margin: 0, fontSize: '2rem', color: '#fff' }}>Asteroid Defender</h1>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                    <h1 style={{ margin: 0, fontSize: '2rem', color: '#fff' }}>Asteroid Defender</h1>
+                    <span
+                        aria-label={`Game state: ${stateBadge.label}`}
+                        style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            padding: '4px 10px',
+                            borderRadius: '999px',
+                            fontSize: '0.72rem',
+                            letterSpacing: '0.08em',
+                            fontWeight: 800,
+                            lineHeight: 1,
+                            textTransform: 'uppercase',
+                            color: stateBadge.color,
+                            background: stateBadge.bg,
+                            border: `1px solid ${stateBadge.border}`,
+                            boxShadow: '0 3px 8px rgba(0,0,0,0.3)',
++                            transition: 'transform 0.2s ease-out',
++                            transform: badgePulse ? 'scale(1.2)' : 'scale(1)',
+                        }}
+                    >
+                        {stateBadge.label}
+                    </span>
+                </div>
 
                 <div style={{
                     background: 'rgba(0, 0, 0, 0.6)',
@@ -83,29 +146,150 @@ export default function HUD() {
                 </div>
             </div>
 
-            <button
-                onClick={openOnboarding}
-                aria-label="Open help"
+            <div
                 style={{
                     position: 'fixed',
                     top: 20,
                     right: 20,
                     zIndex: 120,
-                    width: 48,
-                    height: 48,
-                    borderRadius: '50%',
-                    border: '1px solid rgba(255,255,255,0.35)',
-                    background: 'rgba(8, 12, 24, 0.8)',
-                    color: '#fff',
-                    fontSize: '1.4rem',
-                    fontWeight: 700,
-                    cursor: 'pointer',
-                    backdropFilter: 'blur(6px)',
-                    boxShadow: '0 8px 16px rgba(0,0,0,0.35)'
+                    display: 'flex',
+                    gap: 10,
+                    alignItems: 'center',
                 }}
             >
-                ?
-            </button>
+                {(gameState === 'playing' || gameState === 'paused') && (
+                    <button
+                        onClick={togglePause}
+                        aria-label={gameState === 'playing' ? 'Pause game' : 'Resume game'}
+                        style={{
+                            minWidth: 108,
+                            height: 44,
+                            borderRadius: '10px',
+                            border: '1px solid rgba(126, 200, 255, 0.45)',
+                            background: 'rgba(8, 12, 24, 0.86)',
+                            color: '#dbeafe',
+                            fontSize: '0.95rem',
+                            fontWeight: 700,
+                            cursor: 'pointer',
+                            backdropFilter: 'blur(6px)',
+                            boxShadow: '0 8px 16px rgba(0,0,0,0.35)'
+                        }}
+                    >
+                        {gameState === 'playing' ? 'Pause (Esc)' : 'Resume (Esc)'}
+                    </button>
+                )}
+
+                <button
+                    onClick={openOnboarding}
+                    aria-label="Open help"
+                    style={{
+                        width: 48,
+                        height: 48,
+                        borderRadius: '50%',
+                        border: '1px solid rgba(255,255,255,0.35)',
+                        background: 'rgba(8, 12, 24, 0.8)',
+                        color: '#fff',
+                        fontSize: '1.4rem',
+                        fontWeight: 700,
+                        cursor: 'pointer',
+                        backdropFilter: 'blur(6px)',
+                        boxShadow: '0 8px 16px rgba(0,0,0,0.35)'
+                    }}
+                >
+                    ?
+                </button>
+            </div>
+
+            {gameState === 'menu' && (
+                <div style={{
+                    position: 'fixed',
+                    inset: 0,
+                    backgroundColor: 'rgba(2, 4, 12, 0.84)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    zIndex: 125,
+                    pointerEvents: 'auto',
+                    backdropFilter: 'blur(8px)',
+                    textAlign: 'center',
+                    padding: '24px'
+                }}>
+                    <h1 style={{ color: '#fff', fontSize: '3.2rem', margin: '0 0 0.8rem 0', textShadow: '0 0 20px rgba(126,200,255,0.35)' }}>
+                        Asteroid Defender
+                    </h1>
+                    <p style={{ color: '#bfdbfe', fontSize: '1.15rem', maxWidth: 620, margin: '0 0 1.8rem 0' }}>
+                        Command online. Start the defense cycle when ready, pause at any time with <strong>Esc</strong>, and hold the platform.
+                    </p>
+                    <button
+                        onClick={startGame}
+                        style={{
+                            padding: '16px 32px',
+                            fontSize: '1.2rem',
+                            cursor: 'pointer',
+                            backgroundColor: '#2563eb',
+                            border: 'none',
+                            borderRadius: '10px',
+                            color: '#fff',
+                            fontWeight: 'bold',
+                            letterSpacing: '1px',
+                            boxShadow: '0 10px 25px rgba(37,99,235,0.35)',
+                        }}
+                    >
+                        Start Defense
+                    </button>
+                </div>
+            )}
+
+            {gameState === 'paused' && (
+                <div style={{
+                    position: 'fixed',
+                    inset: 0,
+                    backgroundColor: 'rgba(0,0,0,0.72)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    zIndex: 110,
+                    pointerEvents: 'auto',
+                    backdropFilter: 'blur(6px)'
+                }}>
+                    <h1 style={{ color: '#e2e8f0', fontSize: '3rem', margin: '0 0 0.8rem 0' }}>Simulation Paused</h1>
+                    <p style={{ color: '#bfdbfe', fontSize: '1.05rem', margin: '0 0 1.8rem 0' }}>Press Esc or resume when ready.</p>
+                    <div style={{ display: 'flex', gap: 12 }}>
+                        <button
+                            onClick={resumeGame}
+                            style={{
+                                padding: '12px 24px',
+                                fontSize: '1rem',
+                                cursor: 'pointer',
+                                backgroundColor: '#2563eb',
+                                border: 'none',
+                                borderRadius: '8px',
+                                color: '#fff',
+                                fontWeight: 700,
+                            }}
+                        >
+                            Resume
+                        </button>
+                        <button
+                            onClick={restartGame}
+                            style={{
+                                padding: '12px 24px',
+                                fontSize: '1rem',
+                                cursor: 'pointer',
+                                backgroundColor: '#ef4444',
+                                border: 'none',
+                                borderRadius: '8px',
+                                color: '#fff',
+                                fontWeight: 700,
+                            }}
+                        >
+                            Restart
+                        </button>
+                    </div>
+                </div>
+            )}
 
             {isOnboardingOpen && (
                 <div
@@ -205,7 +389,7 @@ export default function HUD() {
                     <h1 style={{ color: '#ef4444', fontSize: '4rem', margin: '0 0 1rem 0', textShadow: '0 0 20px rgba(239,68,68,0.5)' }}>BASE DESTROYED</h1>
                     <p style={{ color: '#fff', fontSize: '1.5rem', marginBottom: '2rem' }}>You destroyed {asteroidsDestroyed} asteroids before falling.</p>
                     <button
-                        onClick={() => window.location.reload()}
+                        onClick={restartGame}
                         style={{
                             padding: '16px 32px', fontSize: '1.5rem',
                             cursor: 'pointer', backgroundColor: '#ef4444',

--- a/src/components/Turret.tsx
+++ b/src/components/Turret.tsx
@@ -41,7 +41,11 @@ export default function Turret({ id, position, rotation }: TurretProps) {
     useFrame((state) => {
         if (!turretGroup.current) return;
 
-        if (useGameStore.getState().gameState === 'gameover') {
+        if (useGameStore.getState().gameState !== 'playing') {
+            if (currentTargetRef.current?.targetedBy === id) {
+                currentTargetRef.current.targetedBy = null;
+            }
+            currentTargetRef.current = null;
             if (hasTarget) setHasTarget(false);
             return;
         }

--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import useGameStore from './gameStore';
+
+const initialState = useGameStore.getInitialState();
+
+beforeEach(() => {
+  useGameStore.setState(initialState, true);
+});
+
+describe('gameStore gameplay state machine', () => {
+  it('starts in menu state', () => {
+    const state = useGameStore.getState();
+
+    expect(state.gameState).toBe('menu');
+    expect(state.health).toBe(state.maxHealth);
+    expect(state.sessionId).toBe(0);
+  });
+
+  it('startGame resets counters and begins a new session', () => {
+    useGameStore.setState({
+      asteroidsDestroyed: 12,
+      activeAsteroids: 8,
+      health: 14,
+      lastDamageTime: Date.now(),
+    });
+
+    const before = useGameStore.getState().sessionId;
+    useGameStore.getState().startGame();
+    const after = useGameStore.getState();
+
+    expect(after.gameState).toBe('playing');
+    expect(after.asteroidsDestroyed).toBe(0);
+    expect(after.activeAsteroids).toBe(0);
+    expect(after.health).toBe(after.maxHealth);
+    expect(after.lastDamageTime).toBe(0);
+    expect(after.sessionId).toBe(before + 1);
+  });
+
+  it('supports pause and resume transitions', () => {
+    useGameStore.getState().startGame();
+    useGameStore.getState().pauseGame();
+    expect(useGameStore.getState().gameState).toBe('paused');
+
+    useGameStore.getState().resumeGame();
+    expect(useGameStore.getState().gameState).toBe('playing');
+  });
+
+  it('only applies damage while playing', () => {
+    useGameStore.getState().startGame();
+    useGameStore.getState().pauseGame();
+
+    const before = useGameStore.getState().health;
+    useGameStore.getState().takeDamage(20);
+    expect(useGameStore.getState().health).toBe(before);
+
+    useGameStore.getState().resumeGame();
+    useGameStore.getState().takeDamage(20);
+    expect(useGameStore.getState().health).toBe(before - 20);
+  });
+
+  it('sets gameover when health reaches zero and restart creates fresh run', () => {
+    useGameStore.getState().startGame();
+    useGameStore.getState().takeDamage(1000);
+    expect(useGameStore.getState().gameState).toBe('gameover');
+
+    const before = useGameStore.getState().sessionId;
+    useGameStore.getState().restartGame();
+
+    const after = useGameStore.getState();
+    expect(after.gameState).toBe('playing');
+    expect(after.health).toBe(after.maxHealth);
+    expect(after.asteroidsDestroyed).toBe(0);
+    expect(after.activeAsteroids).toBe(0);
+    expect(after.sessionId).toBe(before + 1);
+  });
+});

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1,24 +1,42 @@
 import { create } from 'zustand';
 
+export type GameplayState = 'menu' | 'playing' | 'paused' | 'gameover';
+
 interface GameState {
     asteroidsDestroyed: number;
     activeAsteroids: number;
     health: number;
     maxHealth: number;
-    gameState: 'playing' | 'gameover';
+    gameState: GameplayState;
+    sessionId: number;
     lastDamageTime: number;
     incrementDestroyed: () => void;
     setActiveAsteroids: (count: number) => void;
     takeDamage: (amount: number) => void;
+    startGame: () => void;
+    pauseGame: () => void;
+    resumeGame: () => void;
+    togglePause: () => void;
+    restartGame: () => void;
     resetGame: () => void;
 }
 
+const MAX_HEALTH = 100;
+
+function freshRoundState() {
+    return {
+        asteroidsDestroyed: 0,
+        activeAsteroids: 0,
+        health: MAX_HEALTH,
+        lastDamageTime: 0,
+    };
+}
+
 const useGameStore = create<GameState>((set) => ({
-    asteroidsDestroyed: 0,
-    activeAsteroids: 0,
-    health: 100,
-    maxHealth: 100,
-    gameState: 'playing', // 'playing' or 'gameover'
+    ...freshRoundState(),
+    maxHealth: MAX_HEALTH,
+    gameState: 'menu',
+    sessionId: 0,
     lastDamageTime: 0,
 
     incrementDestroyed: () => set((state) => ({
@@ -28,7 +46,7 @@ const useGameStore = create<GameState>((set) => ({
     setActiveAsteroids: (count) => set({ activeAsteroids: count }),
 
     takeDamage: (amount) => set((state) => {
-        if (state.gameState === 'gameover') return state;
+        if (state.gameState !== 'playing') return state;
         const newHealth = Math.max(0, state.health - amount);
         return {
             health: newHealth,
@@ -37,13 +55,39 @@ const useGameStore = create<GameState>((set) => ({
         };
     }),
 
-    resetGame: () => set({
-        asteroidsDestroyed: 0,
-        activeAsteroids: 0,
-        health: 100,
+    startGame: () => set((state) => ({
+        ...freshRoundState(),
         gameState: 'playing',
-        lastDamageTime: 0
+        sessionId: state.sessionId + 1,
+    })),
+
+    pauseGame: () => set((state) => {
+        if (state.gameState !== 'playing') return state;
+        return { gameState: 'paused' };
     }),
+
+    resumeGame: () => set((state) => {
+        if (state.gameState !== 'paused') return state;
+        return { gameState: 'playing' };
+    }),
+
+    togglePause: () => set((state) => {
+        if (state.gameState === 'playing') return { gameState: 'paused' };
+        if (state.gameState === 'paused') return { gameState: 'playing' };
+        return state;
+    }),
+
+    restartGame: () => set((state) => ({
+        ...freshRoundState(),
+        gameState: 'playing',
+        sessionId: state.sessionId + 1,
+    })),
+
+    resetGame: () => set((state) => ({
+        ...freshRoundState(),
+        gameState: 'playing',
+        sessionId: state.sessionId + 1,
+    })),
 }));
 
 export default useGameStore;


### PR DESCRIPTION
Introduce explicit game states including menu, playing, paused, and gameover. Implement controls for starting the game, pausing/resuming, and restarting without page reload. Ensure that game logic resets cleanly on restart and no duplicate entities remain after multiple cycles.

Fixes #30