### PR TITLE
Issue #35: add game-over run stats and restart hotkey

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -3,12 +3,21 @@ import useGameStore from '../store/gameStore';
 
 const ONBOARDING_STORAGE_KEY = 'asteroid-defender:onboarding-seen-v1';
 
+function formatDuration(milliseconds: number) {
+    const totalSeconds = Math.max(0, Math.floor(milliseconds / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
 export default function HUD() {
     const asteroidsDestroyed = useGameStore((state) => state.asteroidsDestroyed);
     const activeAsteroids = useGameStore((state) => state.activeAsteroids);
     const health = useGameStore((state) => state.health);
     const maxHealth = useGameStore((state) => state.maxHealth);
     const gameState = useGameStore((state) => state.gameState);
+    const runStartedAt = useGameStore((state) => state.runStartedAt);
+    const runEndedAt = useGameStore((state) => state.runEndedAt);
     const startGame = useGameStore((state) => state.startGame);
     const togglePause = useGameStore((state) => state.togglePause);
     const resumeGame = useGameStore((state) => state.resumeGame);
@@ -25,6 +34,8 @@ export default function HUD() {
     const [badgePulse, setBadgePulse] = useState(false);
 
     const healthPercent = maxHealth > 0 ? (health / maxHealth) * 100 : 0;
+    const runDuration = runStartedAt > 0 && runEndedAt !== null ? runEndedAt - runStartedAt : 0;
+    const runDurationLabel = formatDuration(runDuration);
 
     const stateBadge = {
         menu: { label: 'MENU', bg: 'rgba(59,130,246,0.24)', border: 'rgba(96,165,250,0.65)', color: '#bfdbfe' },
@@ -54,12 +65,18 @@ export default function HUD() {
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key !== 'Escape' || event.repeat) return;
+            if (event.repeat) return;
 
             const state = useGameStore.getState();
-            if (state.gameState === 'playing' || state.gameState === 'paused') {
+            if (event.key === 'Escape' && (state.gameState === 'playing' || state.gameState === 'paused')) {
                 event.preventDefault();
                 state.togglePause();
+                return;
+            }
+
+            if ((event.key === 'r' || event.key === 'R') && (state.gameState === 'paused' || state.gameState === 'gameover')) {
+                event.preventDefault();
+                state.restartGame();
             }
         };
 
@@ -355,7 +372,7 @@ export default function HUD() {
                                 fontWeight: 700,
                             }}
                         >
-                            Restart
+                            Restart (R)
                         </button>
                     </div>
                 </div>
@@ -459,6 +476,7 @@ export default function HUD() {
                 }}>
                     <h1 style={{ color: '#ef4444', fontSize: 'clamp(2rem, 6vw, 4rem)', margin: '0 0 1rem 0', textShadow: '0 0 20px rgba(239,68,68,0.5)' }}>BASE DESTROYED</h1>
                     <p style={{ color: '#fff', fontSize: 'clamp(1rem, 3vw, 1.5rem)', marginBottom: '2rem' }}>You destroyed {asteroidsDestroyed} asteroids before falling.</p>
+                    <p style={{ color: '#bfdbfe', fontSize: 'clamp(0.95rem, 2.6vw, 1.25rem)', margin: '0 0 2rem 0' }}>Time survived: {runDurationLabel}</p>
                     <button
                         onClick={restartGame}
                         style={{
@@ -473,7 +491,7 @@ export default function HUD() {
                         onMouseOver={(e) => e.currentTarget.style.transform = 'scale(1.05)'}
                         onMouseOut={(e) => e.currentTarget.style.transform = 'scale(1)'}
                     >
-                        Restart Protocol
+                        Restart Protocol (R)
                     </button>
                 </div>
             )}

--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import useGameStore from './gameStore';
 
 const initialState = useGameStore.getInitialState();
@@ -14,6 +14,8 @@ describe('gameStore gameplay state machine', () => {
     expect(state.gameState).toBe('menu');
     expect(state.health).toBe(state.maxHealth);
     expect(state.sessionId).toBe(0);
+    expect(state.runStartedAt).toBe(0);
+    expect(state.runEndedAt).toBeNull();
   });
 
   it('startGame resets counters and begins a new session', () => {
@@ -72,6 +74,33 @@ describe('gameStore gameplay state machine', () => {
     expect(after.asteroidsDestroyed).toBe(0);
     expect(after.activeAsteroids).toBe(0);
     expect(after.sessionId).toBe(before + 1);
+  });
+
+  it('tracks run start and end timestamps across restart', () => {
+    const nowSpy = vi.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(1000);
+    useGameStore.getState().startGame();
+
+    let state = useGameStore.getState();
+    expect(state.runStartedAt).toBe(1000);
+    expect(state.runEndedAt).toBeNull();
+
+    nowSpy.mockReturnValue(2500);
+    useGameStore.getState().takeDamage(1000);
+
+    state = useGameStore.getState();
+    expect(state.gameState).toBe('gameover');
+    expect(state.runEndedAt).toBe(2500);
+
+    nowSpy.mockReturnValue(4000);
+    useGameStore.getState().restartGame();
+
+    state = useGameStore.getState();
+    expect(state.runStartedAt).toBe(4000);
+    expect(state.runEndedAt).toBeNull();
+
+    nowSpy.mockRestore();
   });
 });
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -10,6 +10,8 @@ interface GameState {
     maxHealth: number;
     gameState: GameplayState;
     sessionId: number;
+    runStartedAt: number;
+    runEndedAt: number | null;
     lastDamageTime: number;
     cameraMode: CameraMode;
     reducedMotion: boolean;
@@ -39,6 +41,8 @@ function freshRoundState() {
         asteroidsDestroyed: 0,
         activeAsteroids: 0,
         health: MAX_HEALTH,
+        runStartedAt: 0,
+        runEndedAt: null,
         lastDamageTime: 0,
     };
 }
@@ -62,11 +66,13 @@ const useGameStore = create<GameState>((set) => ({
 
     takeDamage: (amount) => set((state) => {
         if (state.gameState !== 'playing') return state;
+        const now = Date.now();
         const newHealth = Math.max(0, state.health - amount);
         return {
             health: newHealth,
             gameState: newHealth === 0 ? 'gameover' : state.gameState,
-            lastDamageTime: Date.now()
+            runEndedAt: newHealth === 0 ? (state.runEndedAt ?? now) : state.runEndedAt,
+            lastDamageTime: now
         };
     }),
 
@@ -74,6 +80,7 @@ const useGameStore = create<GameState>((set) => ({
         ...freshRoundState(),
         gameState: 'playing',
         sessionId: state.sessionId + 1,
+        runStartedAt: Date.now(),
     })),
 
     pauseGame: () => set((state) => {
@@ -96,12 +103,14 @@ const useGameStore = create<GameState>((set) => ({
         ...freshRoundState(),
         gameState: 'playing',
         sessionId: state.sessionId + 1,
+        runStartedAt: Date.now(),
     })),
 
     resetGame: () => set((state) => ({
         ...freshRoundState(),
         gameState: 'playing',
         sessionId: state.sessionId + 1,
+        runStartedAt: Date.now(),
     })),
 
     toggleCameraMode: () => set((state) => ({


### PR DESCRIPTION
## Summary\n- add run start/end timestamps to game state for per-run duration tracking\n- show `Time survived` on the game-over overlay\n- add restart keyboard shortcut (`R`) on paused/game-over states\n- label restart buttons with shortcut hint\n- add store tests covering run timestamp lifecycle\n\n## Validation\n- npx vitest run\n- npm run lint\n- npm run build\n\nCloses #35