### PR TITLE
[codex] complete onboarding start flow

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -63,11 +63,47 @@ export default function HUD() {
         }
     }, []);
 
+    const dismissOnboarding = () => {
+        setIsOnboardingOpen(false);
+        try {
+            window.localStorage.setItem(ONBOARDING_STORAGE_KEY, 'true');
+        } catch {
+            // Ignore storage failures; overlay can still be closed for the current session.
+        }
+    };
+
+    const startFromOnboarding = () => {
+        dismissOnboarding();
+        startGame();
+    };
+
+    const openOnboarding = () => {
+        setIsOnboardingOpen(true);
+    };
+
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.repeat) return;
 
             const state = useGameStore.getState();
+            if (event.key === 'Enter' && state.gameState === 'menu') {
+                event.preventDefault();
+                startFromOnboarding();
+                return;
+            }
+
+            if ((event.key === '?' || event.key === 'h' || event.key === 'H') && state.gameState !== 'gameover') {
+                event.preventDefault();
+                openOnboarding();
+                return;
+            }
+
+            if (event.key === 'Escape' && isOnboardingOpen && state.gameState !== 'menu') {
+                event.preventDefault();
+                dismissOnboarding();
+                return;
+            }
+
             if (event.key === 'Escape' && (state.gameState === 'playing' || state.gameState === 'paused')) {
                 event.preventDefault();
                 state.togglePause();
@@ -84,20 +120,9 @@ export default function HUD() {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, []);
+    }, [dismissOnboarding, isOnboardingOpen, openOnboarding, startFromOnboarding]);
 
-    const dismissOnboarding = () => {
-        setIsOnboardingOpen(false);
-        try {
-            window.localStorage.setItem(ONBOARDING_STORAGE_KEY, 'true');
-        } catch {
-            // Ignore storage failures; overlay can still be closed for the current session.
-        }
-    };
-
-    const openOnboarding = () => {
-        setIsOnboardingOpen(true);
-    };
+    const canStartFromOverlay = gameState === 'menu';
 
     return (
         <>
@@ -269,21 +294,23 @@ export default function HUD() {
                 <button
                     onClick={openOnboarding}
                     aria-label="Open help"
+                    title="Help (? / H)"
                     style={{
-                        width: 48,
+                        padding: '0 16px',
+                        minWidth: 74,
                         height: 48,
-                        borderRadius: '50%',
+                        borderRadius: '999px',
                         border: '1px solid rgba(255,255,255,0.35)',
                         background: 'rgba(8, 12, 24, 0.8)',
                         color: '#fff',
-                        fontSize: '1.4rem',
+                        fontSize: '0.95rem',
                         fontWeight: 700,
                         cursor: 'pointer',
                         backdropFilter: 'blur(6px)',
                         boxShadow: '0 8px 16px rgba(0,0,0,0.35)'
                     }}
                 >
-                    ?
+                    Help
                 </button>
             </div>
 
@@ -433,19 +460,27 @@ export default function HUD() {
                         </div>
 
                         <p style={{ margin: '10px 0 12px', color: '#bfdbfe' }}>
-                            Defend the base from incoming asteroids. Turrets auto-target and fire; if asteroids hit the platform, Base Integrity drops.
+                            Defend the base from incoming asteroids. Turrets auto-target and fire, so your job is to manage the defense view, monitor the swarm, and keep Base Integrity above zero.
                         </p>
 
                         <ul style={{ margin: '0 0 14px 18px', padding: 0, display: 'grid', gap: '6px' }}>
                             <li><strong>Base Integrity</strong>: your remaining health.</li>
                             <li><strong>Destroyed</strong>: asteroids eliminated by your defenses.</li>
                             <li><strong>Active Swarm</strong>: current asteroid pressure.</li>
-                            <li><strong>🎬 Cinematic / 📷 Static</strong>: toggle the camera style at any time.</li>
-                            <li><strong>♿ Reduced Motion</strong>: slower cuts and less camera movement.</li>
+                            <li><strong>Enter / Start Defense</strong>: launch the run from the briefing overlay.</li>
+                            <li><strong>Esc</strong>: pause or resume the simulation.</li>
+                            <li><strong>R</strong>: restart while paused or after game over.</li>
+                            <li><strong>? / H</strong>: reopen this help overlay during play.</li>
+                            <li><strong>🎬 Cinematic / 📷 Static</strong>: switch between sweeping showcase shots and a steady tactical view.</li>
+                            <li><strong>♿ Reduced Motion</strong>: slow camera cuts and reduce movement intensity.</li>
                         </ul>
 
+                        <p style={{ margin: '0 0 14px', color: '#cbd5f5' }}>
+                            Cinematic mode performs short camera sweeps between dramatic angles. If you want a steadier view, switch to Static or enable Reduced Motion.
+                        </p>
+
                         <button
-                            onClick={dismissOnboarding}
+                            onClick={canStartFromOverlay ? startFromOnboarding : dismissOnboarding}
                             style={{
                                 width: '100%',
                                 padding: '12px 16px',
@@ -458,7 +493,7 @@ export default function HUD() {
                                 cursor: 'pointer',
                             }}
                         >
-                            Got it — Defend the Base
+                            {canStartFromOverlay ? 'Start Defense (Enter)' : 'Close Help'}
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Closes #33.

This changes the onboarding flow so the first-run mission brief is not just informational: players can now launch the game directly from that overlay, and the same overlay remains available as in-game help.

## User Impact

New players now see the controls, objective, and cinematic camera guidance before combat starts. Returning players still get the normal start screen, and active runs expose a clear Help control plus keyboard shortcuts to reopen the briefing.

## Root Cause

The repository already had most of the issue implemented, but the onboarding modal only dismissed itself. The actual game start action lived in a separate menu overlay, which meant the acceptance criterion about starting from the onboarding overlay was not met. The help copy also omitted some concrete controls and did not clearly explain the cinematic sweep behavior.

## Fix

The HUD now routes the onboarding CTA through the real start action when the game is still in the menu state. It also adds keyboard shortcuts for starting from the briefing (`Enter`) and reopening help (`?` / `H`), renames the HUD help affordance to a visible `Help` button, and expands the overlay copy to cover objective, pause/restart/help controls, camera modes, reduced motion, and cinematic sweeps.

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
