### PR TITLE
docs: align architecture documentation with current implementation

### DIFF
--- a/docs/ARCHITECTURE/001-tech-stack.md
+++ b/docs/ARCHITECTURE/001-tech-stack.md
@@ -4,7 +4,7 @@
 Building a real-time 3D game in the browser requires a stack that can maintain 60 frames per second while handling complex data flows (physics, input, rendering, and game logic). Traditional React state management inherently causes re-renders, which dramatically impacts the performance of a `requestAnimationFrame` based game loop.
 
 ## Decision
-We elected to use the **React Three Fiber (R3F)** ecosystem coupled with an **Entity Component System (ECS)** and a **Web Worker-driven Physics Engine**.
+We elected to use the **React Three Fiber (R3F)** ecosystem coupled with an **Entity Component System (ECS)** and a **WASM-based Physics Engine**.
 
 ### Core Renderer
 - **`three.js`**: WebGL abstraction for 3D mathematics and scene graph.
@@ -13,7 +13,7 @@ We elected to use the **React Three Fiber (R3F)** ecosystem coupled with an **En
 
 ### Physics Engine
 - **`@react-three/rapier`**: A React wrapper for Rapier3D, a hardware-accelerated physics engine compiled to WebAssembly. 
-- *Why:* It offloads complex collision detection and rigid body physics calculations to a background thread, keeping the main thread free for rendering. We use it to drive Asteroid velocity and handle potential entity collisions.
+- *Why:* It uses Rapier compiled to WebAssembly to perform physics calculations efficiently (running on the main thread in this project). We use it to drive Asteroid velocity and handle potential entity collisions.
 
 ### Game State Management (ECS)
 - **`miniplex` & `miniplex-react`**: A lightweight Entity Component System tailored for React and R3F.

--- a/docs/ARCHITECTURE/002-game-mechanics.md
+++ b/docs/ARCHITECTURE/002-game-mechanics.md
@@ -15,8 +15,8 @@ The origin `[0, 0, 0]` serves as the critical defense point. It is a static mesh
   1. `swarmer`: Fast, low health, low damage.
   2. `tank`: Slow, very high health, massive damage on impact.
   3. `splitter`: Medium speed and health. Upon destruction by a turret, it shatters into multiple `swarmer` fragments.
-- **Movement**: Asteroids are spawned perfectly along the boundary of a 40-unit radius sphere. Upon creation, their `<RigidBody>` is assigned a constant linear velocity directly towards the origin.
-- **Data Structure**: Asteroids write their position back into the ECS on every frame and manage their own `health` integer.
+- **Movement**: Asteroids are spawned roughly along a 40-unit radius shell (with a slight vertical flattening to keep the swarm focused in the play area). Upon creation, their `<RigidBody>` is assigned a constant linear velocity directly towards the origin.
+- **Data Structure**: Asteroids write their position back into the ECS on every frame and manage their own `health` value (which can be fractional due to per-frame damage).
 
 ### 3. The Turret Defenses (Automata)
 There are four turrets rigidly mounted to the top and bottom of the platform.

--- a/docs/ARCHITECTURE/base_health_and_game_over.md
+++ b/docs/ARCHITECTURE/base_health_and_game_over.md
@@ -5,7 +5,7 @@ The application was modified to introduce a lose condition where asteroids that 
 
 ## Components Modified
 
-### 1. Store (`gameStore.js`)
+### 1. Store (`gameStore.ts`)
 - Introduced `health` and `maxHealth` to track platform integrity.
 - Introduced `gameState` to distinguish between `'playing'` and `'gameover'` modes.
 - Added `takeDamage(amount)` action that deducts health and triggers the `'gameover'` state if health reaches 0.
@@ -13,7 +13,7 @@ The application was modified to introduce a lose condition where asteroids that 
 
 ### 2. Collision & Damage Logic (`Asteroid.jsx`)
 - Modifed the movement logic inside `useFrame`.
-- Asteroids continuously compute their distance to the origin `(0,0,0)`. If `currentPos.length() <= 3` (simulating hitting the platform collider), the asteroid is destroyed, triggering the explosion UI and deducting 10 health from the base via the `useGameStore`.
+- Asteroids continuously compute their distance to the origin `(0,0,0)`. If `currentPos.length() <= 3` (simulating hitting the platform collider), the asteroid is destroyed, triggering the explosion UI and deducting health from the base via `useGameStore` based on the asteroid's `damage` stat (e.g. 5 / 10 / 30 depending on class).
 - During `'gameover'` state, the rigid bodies are frozen by setting `linvel` and `angvel` to zero.
 
 ### 3. Destruction Handling (`GameScene.jsx`)
@@ -29,4 +29,4 @@ The application was modified to introduce a lose condition where asteroids that 
 ### 5. UI Layer (`HUD.jsx`)
 - Added a health bar widget to the main HUD showing `Base Integrity`.
 - Added a fullscreen overlay that appears when `gameState === 'gameover'`, showing a "BASE DESTROYED" message, the final score, and a "Restart Protocol" button.
-- The restart button currently calls `window.location.reload()`, which efficiently resets the entire React Three Fiber canvas, Rapier physics world, and custom ECS data.
+- The restart button triggers the `restartGame()` action in the global store, which resets health/score/session state and reinitializes the ECS without requiring a full page reload.


### PR DESCRIPTION
This PR updates the architecture docs to match the current codebase behavior:
- Corrects the restart behavior to use restartGame() instead of window.location.reload()
- Clarifies that asteroid damage varies by class (not fixed 10)
- Clarifies Rapier runs as WASM on the main thread (not a web worker)
- Updates asteroid spawn description to reflect the actual sampling method (rounded shell with vertical flattening)
