### PR TITLE
🧹 Type DepthOfField ref correctly

### DIFF
--- a/src/components/PostEffects.tsx
+++ b/src/components/PostEffects.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { EffectComposer, Bloom, DepthOfField } from '@react-three/postprocessing';
+import { DepthOfFieldEffect } from 'postprocessing';
 import { MathUtils } from 'three';
 import { dofSettings } from './CinematicCamera';
 
@@ -10,13 +11,16 @@ import { dofSettings } from './CinematicCamera';
  * instead of snapping instantly to the next focus distance.
  */
 function DynamicDepthOfField() {
-    const dofRef = useRef<any>(null);
+    const dofRef = useRef<DepthOfFieldEffect>(null);
 
     useFrame((_, delta) => {
         if (dofRef.current) {
-            // Smoothly interpolate current focus distance towards the target distance
-            dofRef.current.target = MathUtils.lerp(
-                dofRef.current.target,
+            // Smoothly interpolate current focus distance towards the target distance.
+            // Note: We interpolate the underlying material's focusDistance property
+            // directly as the library's 'target' property is reserved for Vector3
+            // auto-focus targets.
+            dofRef.current.cocMaterial.focusDistance = MathUtils.lerp(
+                dofRef.current.cocMaterial.focusDistance,
                 dofSettings.focusDistance,
                 delta * 2 // Lerp speed
             );


### PR DESCRIPTION
🎯 **What:** Replaced the `any` type for the `dofRef` in `PostEffects.tsx` with the correct `DepthOfFieldEffect` type from the `postprocessing` library.

💡 **Why:** This improves maintainability and type safety in the post-processing component. During the refactor, it was identified that the code was incorrectly treating the `target` property as a number for focus distance. In the `postprocessing` library, `target` is a `Vector3 | null` for auto-focus, while manual focus distance is controlled via `cocMaterial.focusDistance`. The fix aligns the code with the actual library API.

✅ **Verification:** 
- Ran `pnpm lint` and `pnpm test`, both of which passed.
- Verified type safety for the modified file using `tsc`.
- Confirmed that `DepthOfFieldEffect` from `postprocessing` contains the `cocMaterial.focusDistance` property.

✨ **Result:** Improved type safety and fixed a latent bug where the wrong property was being targeted for focus distance interpolation.

---
*PR created automatically by Jules for task [12463913626254207369](https://jules.google.com/task/12463913626254207369) started by @deadronos*