### PR TITLE
Fix TypeScript ESLint coverage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,28 +2,63 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
   globalIgnores(['dist']),
   {
-    files: ['**/*.{js,jsx}'],
+    files: ['**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+  },
+  {
+    files: ['src/**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      globals: globals.browser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+  },
+  {
+    files: ['*.config.{js,ts}', 'vite.config.js', 'eslint.config.js'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+  {
+    files: ['**/*.{js,mjs,cjs,jsx}'],
     extends: [
       js.configs.recommended,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
     languageOptions: {
-      ecmaVersion: 2020,
-      globals: globals.browser,
       parserOptions: {
-        ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },
-        sourceType: 'module',
       },
     },
     rules: {
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]', argsIgnorePattern: '^_' }],
+    },
+  },
+  {
+    files: ['**/*.{ts,mts,cts,tsx}'],
+    extends: [
+      ...tseslint.configs.recommended,
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]', argsIgnorePattern: '^_' }],
     },
   },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "typescript": "^5.9.3",
+        "typescript-eslint": "^8.57.1",
         "vite": "^8.0.1",
         "vitest": "^4.1.0"
       }
@@ -1216,6 +1217,301 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/type-utils": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.1",
+        "@typescript-eslint/types": "^8.57.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.1",
+        "@typescript-eslint/tsconfig-utils": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
@@ -3367,6 +3663,19 @@
       "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3437,6 +3746,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
+      "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.57.1",
+        "@typescript-eslint/parser": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.57.1",
     "vite": "^8.0.1",
     "vitest": "^4.1.0"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,10 @@ const PostEffects = lazy(() => import('./components/PostEffects'));
 
 function App() {
   const [dpr, setDpr] = useState(1.5);
-  const gameState = useGameStore((state) => state.gameState);
+  const { gameState, sessionId } = useGameStore((state) => ({
+    gameState: state.gameState,
+    sessionId: state.sessionId,
+  }));
 
   return (
     <>
@@ -28,7 +31,7 @@ function App() {
           <color attach="background" args={['#050510']} />
           <Suspense fallback={null}>
             <Physics paused={gameState !== 'playing'}>
-              <GameScene />
+              <GameScene key={sessionId} />
             </Physics>
           </Suspense>
           <Suspense fallback={null}>

--- a/src/components/AsteroidField.tsx
+++ b/src/components/AsteroidField.tsx
@@ -132,6 +132,9 @@ export default function AsteroidField({ onDestroy }: AsteroidFieldProps) {
   };
 
   useEffect(() => {
+    const runtimes = runtimesRef.current;
+    const runtimeById = runtimeByIdRef.current;
+
     for (const type of ASTEROID_TYPES) {
       const mesh = meshRefs.current[type];
       if (mesh) {
@@ -141,12 +144,12 @@ export default function AsteroidField({ onDestroy }: AsteroidFieldProps) {
     }
 
     return () => {
-      for (const runtime of runtimesRef.current) {
+      for (const runtime of runtimes) {
         
         ECS.remove(runtime.entity);
       }
-      runtimesRef.current.length = 0;
-      runtimeByIdRef.current.clear();
+      runtimes.length = 0;
+      runtimeById.clear();
       runtimeTypeCountsRef.current = { swarmer: 0, tank: 0, splitter: 0 };
       activeCountRef.current = 0;
       useGameStore.getState().setActiveAsteroids(0);

--- a/src/components/CinematicCamera.tsx
+++ b/src/components/CinematicCamera.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import useGameStore from '../store/gameStore';
+import { dofSettings } from './cinematicCameraDof';
 
 /** Seconds each shot is held before the next transition begins */
 const SHOT_DURATION = 17;
@@ -122,16 +123,7 @@ function findNextSafeShot(currentIdx: number, blockedShots: Set<number>): number
     return currentIdx;
 }
 
-/**
- * Shared mutable object – mutated by CinematicCamera on every shot change,
- * read by DynamicDepthOfField in App.tsx.  Using a plain object avoids the
- * overhead of Zustand or React context for per-shot (not per-frame) updates.
- */
-export const dofSettings = {
-    focusDistance: SHOTS[0].focusDist,
-    focalLength: 0.025,
-    bokehScale: 3,
-};
+const tempShakeOffset = new THREE.Vector3();
 
 /**
  * Cinematic camera manager.
@@ -359,9 +351,12 @@ export default function CinematicCamera() {
             if (timeSinceDamage < 0.5) {
                 const shakeScale = reducedMotion ? 0.3 : 1.0;
                 const shakeIntensity = (0.5 - timeSinceDamage) * 2.0 * shakeScale;
-                camera.position.x += (Math.random() - 0.5) * shakeIntensity;
-                camera.position.y += (Math.random() - 0.5) * shakeIntensity;
-                camera.position.z += (Math.random() - 0.5) * shakeIntensity * 0.5;
+                tempShakeOffset.set(
+                    (Math.random() - 0.5) * shakeIntensity,
+                    (Math.random() - 0.5) * shakeIntensity,
+                    (Math.random() - 0.5) * shakeIntensity * 0.5,
+                );
+                camera.position.add(tempShakeOffset);
             }
         }
     });

--- a/src/components/Explosion.tsx
+++ b/src/components/Explosion.tsx
@@ -3,7 +3,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { AsteroidType } from '../ecs/world';
 
-export const EXPLOSION_COLORS: Record<AsteroidType, string> = {
+const EXPLOSION_COLORS: Record<AsteroidType, string> = {
     swarmer: '#d4a843',
     tank: '#555555',
     splitter: '#a855f7',

--- a/src/components/GameScene.tsx
+++ b/src/components/GameScene.tsx
@@ -60,11 +60,10 @@ export default function GameScene() {
 
     const explosionsRef = useRef<PooledExplosion[]>([]);
 
-    const { incrementDestroyed, setActiveAsteroids, sessionId } = useGameStore(
+    const { incrementDestroyed, setActiveAsteroids } = useGameStore(
         useShallow((state) => ({
             incrementDestroyed: state.incrementDestroyed,
             setActiveAsteroids: state.setActiveAsteroids,
-            sessionId: state.sessionId,
         }))
     );
 
@@ -81,32 +80,13 @@ export default function GameScene() {
     }, []);
 
     useEffect(() => {
+        clearAsteroidSpawns();
+
         return () => {
+            clearAsteroidSpawns();
             clearExplosionTimers(explosionsRef.current);
         };
     }, [clearExplosionTimers]);
-
-    useEffect(() => {
-        clearAsteroidSpawns();
-        setShieldImpacts([]);
-        setAsteroids((prev) => prev.map((ast) => ({
-            ...ast,
-            active: false,
-            pos: [0, -1000, 0],
-        })));
-        setExplosions((prev) => prev.map((exp) => {
-            if (exp.timer) {
-                clearTimeout(exp.timer);
-            }
-            return {
-                ...exp,
-                active: false,
-                pos: [0, -1000, 0],
-                timer: undefined,
-            };
-        }));
-        setActiveAsteroids(0);
-    }, [sessionId, setActiveAsteroids]);
 
     const triggerExplosion = useCallback((pos: [number, number, number], type: AsteroidType) => {
         setExplosions(prev => {

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,9 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import useGameStore from '../store/gameStore';
 import { getSecureItem, setSecureItem } from '../utils/storage';
 
 const ONBOARDING_STORAGE_KEY = 'asteroid-defender:onboarding-seen-v1';
+
+function getInitialOnboardingOpen() {
+    try {
+        return getSecureItem(ONBOARDING_STORAGE_KEY) !== 'true';
+    } catch {
+        // If storage is unavailable, default to showing onboarding for accessibility.
+        return true;
+    }
+}
 
 function formatDuration(milliseconds: number) {
     const totalSeconds = Math.max(0, Math.floor(milliseconds / 1000));
@@ -54,9 +63,7 @@ export default function HUD() {
             toggleCinematicIndicator: state.toggleCinematicIndicator,
         }))
     );
-    const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
-    // trigger a brief visual pulse when the game state changes
-    const [badgePulse, setBadgePulse] = useState(false);
+    const [isOnboardingOpen, setIsOnboardingOpen] = useState(getInitialOnboardingOpen);
 
     const healthPercent = maxHealth > 0 ? (health / maxHealth) * 100 : 0;
     const runDuration = runStartedAt > 0 && runEndedAt !== null ? runEndedAt - runStartedAt : 0;
@@ -68,43 +75,24 @@ export default function HUD() {
         paused: { label: 'PAUSED', bg: 'rgba(245,158,11,0.2)', border: 'rgba(251,191,36,0.65)', color: '#fef3c7' },
         gameover: { label: 'GAME OVER', bg: 'rgba(239,68,68,0.2)', border: 'rgba(248,113,113,0.6)', color: '#fee2e2' },
     }[gameState];
-    // animate badge on state transitions
-    useEffect(() => {
-        // pulse the badge then clear after animation duration
-        setBadgePulse(true);
-        const t = setTimeout(() => setBadgePulse(false), 200);
-        return () => clearTimeout(t);
-    }, [gameState]);
 
-    useEffect(() => {
-        try {
-            const hasSeenOnboarding = getSecureItem(ONBOARDING_STORAGE_KEY) === 'true';
-            if (!hasSeenOnboarding) {
-                setIsOnboardingOpen(true);
-            }
-        } catch {
-            // If storage is unavailable, default to showing onboarding for accessibility.
-            setIsOnboardingOpen(true);
-        }
-    }, []);
-
-    const dismissOnboarding = () => {
+    const dismissOnboarding = useCallback(() => {
         setIsOnboardingOpen(false);
         try {
             setSecureItem(ONBOARDING_STORAGE_KEY, 'true');
         } catch {
             // Ignore storage failures; overlay can still be closed for the current session.
         }
-    };
+    }, []);
 
-    const startFromOnboarding = () => {
+    const startFromOnboarding = useCallback(() => {
         dismissOnboarding();
         startGame();
-    };
+    }, [dismissOnboarding, startGame]);
 
-    const openOnboarding = () => {
+    const openOnboarding = useCallback(() => {
         setIsOnboardingOpen(true);
-    };
+    }, []);
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
@@ -165,6 +153,7 @@ export default function HUD() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                     <h1 style={{ margin: 0, fontSize: 'clamp(1.25rem, 3.5vw, 2rem)', color: '#fff' }}>Asteroid Defender</h1>
                     <span
+                        key={gameState}
                         aria-label={`Game state: ${stateBadge.label}`}
                         style={{
                             display: 'inline-flex',
@@ -181,8 +170,7 @@ export default function HUD() {
                             background: stateBadge.bg,
                             border: `1px solid ${stateBadge.border}`,
                             boxShadow: '0 3px 8px rgba(0,0,0,0.3)',
-                            transition: 'transform 0.2s ease-out',
-                            transform: badgePulse ? 'scale(1.2)' : 'scale(1)',
+                            animation: 'hud-badge-pulse 0.2s ease-out',
                         }}
                     >
                         {stateBadge.label}

--- a/src/components/PostEffects.tsx
+++ b/src/components/PostEffects.tsx
@@ -3,7 +3,7 @@ import { useFrame } from '@react-three/fiber';
 import { EffectComposer, Bloom, DepthOfField } from '@react-three/postprocessing';
 import { DepthOfFieldEffect } from 'postprocessing';
 import { MathUtils } from 'three';
-import { dofSettings } from './CinematicCamera';
+import { dofSettings } from './cinematicCameraDof';
 
 /**
  * Bridges the imperative dofSettings singleton (mutated by CinematicCamera on

--- a/src/components/SpaceBackground.tsx
+++ b/src/components/SpaceBackground.tsx
@@ -158,22 +158,24 @@ function Nebula() {
 
 const DUST_COUNT = 400;
 
+function createSpaceDustData() {
+    const positions = new Float32Array(DUST_COUNT * 3);
+    const velocities = new Float32Array(DUST_COUNT * 3);
+    for (let i = 0; i < DUST_COUNT; i++) {
+        positions[i * 3] = (Math.random() - 0.5) * 50;
+        positions[i * 3 + 1] = (Math.random() - 0.5) * 50;
+        positions[i * 3 + 2] = (Math.random() - 0.5) * 50;
+        velocities[i * 3] = (Math.random() - 0.5) * 0.25;
+        velocities[i * 3 + 1] = (Math.random() - 0.5) * 0.25;
+        velocities[i * 3 + 2] = (Math.random() - 0.5) * 0.25;
+    }
+
+    return { positions, velocities };
+}
+
 function SpaceDust() {
     const pointsRef = useRef<THREE.Points>(null);
-
-    const { positions, velocities } = useMemo(() => {
-        const positions = new Float32Array(DUST_COUNT * 3);
-        const velocities = new Float32Array(DUST_COUNT * 3);
-        for (let i = 0; i < DUST_COUNT; i++) {
-            positions[i * 3] = (Math.random() - 0.5) * 50;
-            positions[i * 3 + 1] = (Math.random() - 0.5) * 50;
-            positions[i * 3 + 2] = (Math.random() - 0.5) * 50;
-            velocities[i * 3] = (Math.random() - 0.5) * 0.25;
-            velocities[i * 3 + 1] = (Math.random() - 0.5) * 0.25;
-            velocities[i * 3 + 2] = (Math.random() - 0.5) * 0.25;
-        }
-        return { positions, velocities };
-    }, []);
+    const [{ positions, velocities }] = useState(createSpaceDustData);
 
     useFrame((_, delta) => {
         if (!pointsRef.current) return;
@@ -217,6 +219,28 @@ interface ShootingStarProps {
 const STREAK_VERT = `void main() { gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }`;
 const STREAK_FRAG = `uniform float uOpacity; void main() { gl_FragColor = vec4(0.87, 0.93, 1.0, uOpacity); }`;
 
+function createShootingStarTrajectory() {
+    // Place the start point on a background sphere
+    const theta = Math.random() * Math.PI * 2;
+    const phi = (Math.random() * 0.6 + 0.2) * Math.PI;
+    const r = 90;
+    const startPos = new THREE.Vector3(
+        r * Math.sin(phi) * Math.cos(theta),
+        r * Math.sin(phi) * Math.sin(theta),
+        r * Math.cos(phi),
+    );
+    // Velocity tangential to the sphere so the streak crosses the sky
+    const tangent = new THREE.Vector3(-Math.sin(theta), Math.cos(theta), 0).normalize();
+    const speed = 28 + Math.random() * 22;
+    const velocity = tangent.clone().multiplyScalar(speed);
+
+    // Orient the streak mesh along the velocity direction
+    const quaternion = new THREE.Quaternion();
+    quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), tangent);
+
+    return { startPos, velocity, quaternion };
+}
+
 function ShootingStar({ onComplete }: ShootingStarProps) {
     const meshRef = useRef<THREE.Mesh>(null);
     const matRef = useRef<THREE.ShaderMaterial>(null);
@@ -224,28 +248,7 @@ function ShootingStar({ onComplete }: ShootingStarProps) {
     const doneRef = useRef(false);
     // Shader uniform updated directly each frame — no material property mutation
     const uniforms = useMemo(() => ({ uOpacity: { value: 0 } }), []);
-
-    const { startPos, velocity, quaternion } = useMemo(() => {
-        // Place the start point on a background sphere
-        const theta = Math.random() * Math.PI * 2;
-        const phi = (Math.random() * 0.6 + 0.2) * Math.PI;
-        const r = 90;
-        const startPos = new THREE.Vector3(
-            r * Math.sin(phi) * Math.cos(theta),
-            r * Math.sin(phi) * Math.sin(theta),
-            r * Math.cos(phi),
-        );
-        // Velocity tangential to the sphere so the streak crosses the sky
-        const tangent = new THREE.Vector3(-Math.sin(theta), Math.cos(theta), 0).normalize();
-        const speed = 28 + Math.random() * 22;
-        const velocity = tangent.clone().multiplyScalar(speed);
-
-        // Orient the streak mesh along the velocity direction
-        const quaternion = new THREE.Quaternion();
-        quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), tangent);
-
-        return { startPos, velocity, quaternion };
-    }, []);
+    const [{ startPos, velocity, quaternion }] = useState(createShootingStarTrajectory);
 
     useFrame((_, delta) => {
         if (!meshRef.current || doneRef.current) return;
@@ -287,8 +290,9 @@ function ShootingStar({ onComplete }: ShootingStarProps) {
 
 function ShootingStars() {
     const [activeStars, setActiveStars] = useState<number[]>([]);
+    const [initialSpawnDelay] = useState(() => 3 + Math.random() * 5);
     const timerRef = useRef(0);
-    const nextSpawnRef = useRef(3 + Math.random() * 5);
+    const nextSpawnRef = useRef(initialSpawnDelay);
     const counterRef = useRef(0);
 
     useFrame((_, delta) => {

--- a/src/components/Turret.tsx
+++ b/src/components/Turret.tsx
@@ -20,7 +20,8 @@ const tempVec = new THREE.Vector3();
 export default function Turret({ id, position, rotation }: TurretProps) {
     const turretGroup = useRef<THREE.Group>(null);
     const [hasTarget, setHasTarget] = useState(false);
-    const baseRotation = useMemo(() => new THREE.Euler(rotation[0], rotation[1], rotation[2]), [rotation[0], rotation[1], rotation[2]]);
+    const [rotationX, rotationY, rotationZ] = rotation;
+    const baseRotation = useMemo(() => new THREE.Euler(rotationX, rotationY, rotationZ), [rotationX, rotationY, rotationZ]);
     const idleOffsetRef = useRef(Math.random() * Math.PI * 2);
     const nextRecalibrationRef = useRef(6 + Math.random() * 5);
     const recalibrationStartRef = useRef<number | null>(null);

--- a/src/components/cinematicCameraDof.ts
+++ b/src/components/cinematicCameraDof.ts
@@ -1,0 +1,5 @@
+export const dofSettings = {
+    focusDistance: 0.032,
+    focalLength: 0.025,
+    bokehScale: 3,
+};

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,17 @@ body, html, #root {
   color: white;
   font-family: sans-serif;
 }
+
+@keyframes hud-badge-pulse {
+  0% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.2);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -79,7 +79,7 @@ describe('storage utility', () => {
         const value = 'true';
 
         // Mock setItem to throw
-        const setItemMock = vi.spyOn(globalThis.localStorage, 'setItem').mockImplementation(() => {
+        vi.spyOn(globalThis.localStorage, 'setItem').mockImplementation(() => {
             throw new Error('Storage full');
         });
 

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,9 +4,11 @@
         "skipLibCheck": true,
         "module": "ESNext",
         "moduleResolution": "bundler",
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "allowJs": true
     },
     "include": [
-        "vite.config.ts"
+        "vite.config.js",
+        "eslint.config.js"
     ]
 }


### PR DESCRIPTION
## Summary
- add `typescript-eslint` and update `eslint.config.js` so TS/TSX files are actually linted
- fix the stale `tsconfig.node.json` reference so it points at the current JS config files
- address the newly surfaced lint issues in HUD, scene reset logic, camera/post-effects sharing, background randomness, and tests

## Details
- expanded ESLint file coverage from JS/JSX-only to include TS/TSX
- kept React hooks and Vite fast-refresh rules active for the TypeScript app code
- moved shared DoF settings out of `CinematicCamera.tsx` to satisfy fast-refresh linting
- switched `GameScene` reset behavior to session-keyed remounting instead of effect-time local state resets
- replaced render-time random initialization patterns in `SpaceBackground.tsx` with lazy state initialization
- cleaned smaller warnings in `Turret.tsx`, `AsteroidField.tsx`, and `storage.test.ts`

## Verification
- `npm run lint`
- `npm test`
- `npm run build`

Closes #60
