### PR TITLE
🧹 reduce deep nesting in spatial index query

### DIFF
--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -49,6 +49,25 @@ function getRangeCellBounds(position: THREE.Vector3, range: number): CellBounds 
   };
 }
 
+function visitAsteroidsInCell(
+  cell: GameEntity[],
+  position: THREE.Vector3,
+  rangeSq: number,
+  visitor: (entity: GameEntity, distSq: number) => void,
+) {
+  for (let i = 0; i < cell.length; i++) {
+    const entity = cell[i];
+    if (!entity.position) {
+      continue;
+    }
+
+    const distSq = position.distanceToSquared(entity.position);
+    if (distSq <= rangeSq) {
+      visitor(entity, distSq);
+    }
+  }
+}
+
 function visitAsteroidsInRange(
   position: THREE.Vector3,
   range: number,
@@ -62,20 +81,8 @@ function visitAsteroidsInRange(
       for (let z = minZ; z <= maxZ; z++) {
         const key = getCellKey(x, y, z);
         const cell = asteroidCells.get(key);
-        if (!cell || cell.length === 0) {
-          continue;
-        }
-
-        for (let i = 0; i < cell.length; i++) {
-          const entity = cell[i];
-          if (!entity.position) {
-            continue;
-          }
-
-          const distSq = position.distanceToSquared(entity.position);
-          if (distSq <= rangeSq) {
-            visitor(entity, distSq);
-          }
+        if (cell && cell.length > 0) {
+          visitAsteroidsInCell(cell, position, rangeSq, visitor);
         }
       }
     }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was deep nesting in the spatial index query logic within `src/ecs/world.ts`.
💡 **Why:** Reducing nesting depth improves the maintainability and readability of the codebase by making the logic easier to follow and reason about.
✅ **Verification:** The refactoring was verified through careful code inspection and manual logic verification. Existing tests were attempted but were blocked by environment issues (missing dependencies). A code review was performed and approved.
✨ **Result:** The `visitAsteroidsInRange` function is now much flatter, delegating per-cell processing to a dedicated helper function `visitAsteroidsInCell`.

---
*PR created automatically by Jules for task [8551769771321417135](https://jules.google.com/task/8551769771321417135) started by @deadronos*