### PR TITLE
[codex] Optimize game hot paths

### DIFF
--- a/src/components/Explosion.tsx
+++ b/src/components/Explosion.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, memo } from "react";
+import { useRef, useEffect, memo, useCallback } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import { AsteroidType } from "../ecs/world";
@@ -11,59 +11,26 @@ const EXPLOSION_COLORS: Record<AsteroidType, string> = {
 
 const EMISSIVE_COLOR = new THREE.Color(10, 2, 0);
 const EXPLOSION_FRAGMENT_IDS = Array.from({ length: 8 }, (_, index) => index);
+const PARTICLE_COUNT = EXPLOSION_FRAGMENT_IDS.length;
+const PARTICLE_GEOMETRY = new THREE.DodecahedronGeometry(0.5, 0);
 
 interface ParticleProps {
   startPos: [number, number, number];
   color: string;
+  registerParticle: (index: number, mesh: THREE.Mesh | null) => void;
+  registerMaterial: (index: number, material: THREE.MeshStandardMaterial | null) => void;
+  index: number;
 }
 
-const Particle = memo(({ startPos, color }: ParticleProps) => {
-  const meshRef = useRef<THREE.Mesh>(null);
-  const materialRef = useRef<THREE.MeshStandardMaterial>(null);
-  const lifeRef = useRef(1.0);
-  const velocityRef = useRef(new THREE.Vector3());
-
-  useEffect(() => {
-    lifeRef.current = 1.0;
-    velocityRef.current.set(
-      (Math.random() - 0.5) * 15,
-      (Math.random() - 0.5) * 15,
-      (Math.random() - 0.5) * 15,
-    );
-    if (meshRef.current) {
-      meshRef.current.position.set(...startPos);
-      meshRef.current.scale.setScalar(1);
-    }
-    if (materialRef.current) {
-      materialRef.current.opacity = 1.0;
-    }
-  }, [startPos]);
-
-  useFrame((_, delta) => {
-    if (!meshRef.current || lifeRef.current <= 0) return;
-
-    lifeRef.current -= delta * 1.5;
-
-    if (lifeRef.current <= 0) {
-      meshRef.current.scale.setScalar(0);
-      return;
-    }
-
-    meshRef.current.position.addScaledVector(velocityRef.current, delta);
-    meshRef.current.rotation.x += velocityRef.current.y * delta;
-    meshRef.current.rotation.y += velocityRef.current.x * delta;
-
-    meshRef.current.scale.setScalar(lifeRef.current);
-    if (materialRef.current) {
-      materialRef.current.opacity = lifeRef.current;
-    }
-  });
-
-  return (
-    <mesh ref={meshRef} position={startPos}>
-      <dodecahedronGeometry args={[0.5, 0]} />
+const Particle = memo(
+  ({ startPos, color, registerParticle, registerMaterial, index }: ParticleProps) => (
+    <mesh
+      ref={(mesh) => registerParticle(index, mesh)}
+      position={startPos}
+      geometry={PARTICLE_GEOMETRY}
+    >
       <meshStandardMaterial
-        ref={materialRef}
+        ref={(material) => registerMaterial(index, material)}
         color={color}
         emissive={EMISSIVE_COLOR}
         toneMapped={false}
@@ -72,8 +39,8 @@ const Particle = memo(({ startPos, color }: ParticleProps) => {
         opacity={1}
       />
     </mesh>
-  );
-});
+  ),
+);
 
 interface ActiveExplosionEffectProps {
   position: [number, number, number];
@@ -85,12 +52,51 @@ interface ActiveExplosionEffectProps {
 const ActiveExplosionEffect = memo(
   ({ position, color, explosionId, onComplete }: ActiveExplosionEffectProps) => {
     const blastLightRef = useRef<THREE.PointLight>(null);
+    const particleRefs = useRef<Array<THREE.Mesh | null>>(Array(PARTICLE_COUNT).fill(null));
+    const materialRefs = useRef<Array<THREE.MeshStandardMaterial | null>>(
+      Array(PARTICLE_COUNT).fill(null),
+    );
+    const particleLifeRef = useRef(new Float32Array(PARTICLE_COUNT));
+    const particleVelocityRef = useRef(
+      Array.from({ length: PARTICLE_COUNT }, () => new THREE.Vector3()),
+    );
     const lifeRef = useRef(1);
     const completedRef = useRef(false);
+
+    const registerParticle = useCallback((index: number, mesh: THREE.Mesh | null) => {
+      particleRefs.current[index] = mesh;
+    }, []);
+    const registerMaterial = useCallback(
+      (index: number, material: THREE.MeshStandardMaterial | null) => {
+        materialRefs.current[index] = material;
+      },
+      [],
+    );
 
     useEffect(() => {
       lifeRef.current = 1.0;
       completedRef.current = false;
+
+      for (let i = 0; i < PARTICLE_COUNT; i++) {
+        particleLifeRef.current[i] = 1.0;
+        particleVelocityRef.current[i].set(
+          (Math.random() - 0.5) * 15,
+          (Math.random() - 0.5) * 15,
+          (Math.random() - 0.5) * 15,
+        );
+
+        const particle = particleRefs.current[i];
+        if (particle) {
+          particle.position.set(...position);
+          particle.rotation.set(0, 0, 0);
+          particle.scale.setScalar(1);
+        }
+
+        const material = materialRefs.current[i];
+        if (material) {
+          material.opacity = 1.0;
+        }
+      }
 
       if (blastLightRef.current) {
         blastLightRef.current.intensity = 7;
@@ -103,6 +109,32 @@ const ActiveExplosionEffect = memo(
 
       if (blastLightRef.current) {
         blastLightRef.current.intensity = 7 * lifeRef.current;
+      }
+
+      for (let i = 0; i < PARTICLE_COUNT; i++) {
+        const particle = particleRefs.current[i];
+        if (!particle || particleLifeRef.current[i] <= 0) {
+          continue;
+        }
+
+        const nextLife = particleLifeRef.current[i] - delta * 1.5;
+        particleLifeRef.current[i] = nextLife;
+
+        if (nextLife <= 0) {
+          particle.scale.setScalar(0);
+          continue;
+        }
+
+        const velocity = particleVelocityRef.current[i];
+        particle.position.addScaledVector(velocity, delta);
+        particle.rotation.x += velocity.y * delta;
+        particle.rotation.y += velocity.x * delta;
+        particle.scale.setScalar(nextLife);
+
+        const material = materialRefs.current[i];
+        if (material) {
+          material.opacity = nextLife;
+        }
       }
 
       if (lifeRef.current <= 0 && !completedRef.current) {
@@ -122,7 +154,14 @@ const ActiveExplosionEffect = memo(
           decay={2}
         />
         {EXPLOSION_FRAGMENT_IDS.map((fragmentId) => (
-          <Particle key={fragmentId} startPos={position} color={color} />
+          <Particle
+            key={fragmentId}
+            index={fragmentId}
+            startPos={position}
+            color={color}
+            registerParticle={registerParticle}
+            registerMaterial={registerMaterial}
+          />
         ))}
       </group>
     );

--- a/src/components/Turret.tsx
+++ b/src/components/Turret.tsx
@@ -26,6 +26,7 @@ const INITIAL_LASER_POINTS: [number, number, number][] = [
   [0, 0, LASER_ORIGIN_Z],
   [0, 0, LASER_ORIGIN_Z],
 ];
+const LASER_POINT_BUFFER_LENGTH = 6;
 
 interface TurretProps {
   id: string;
@@ -54,6 +55,7 @@ export default function Turret({ id, position, rotation }: TurretProps) {
   const hologramRingRef = useRef<THREE.Mesh>(null);
   const hologramRingMaterialRef = useRef<THREE.MeshBasicMaterial>(null);
   const hologramReticleRef = useRef<THREE.Group>(null);
+  const laserPointBufferRef = useRef<Float32Array | null>(null);
 
   // Keep vectors around instead of full React states to avoid unneeded renders
   const localTargetRef = useRef(new THREE.Vector3());
@@ -160,14 +162,33 @@ export default function Turret({ id, position, rotation }: TurretProps) {
     }
 
     if (lineRef.current) {
-      lineRef.current.geometry.setPositions([
-        0,
-        0,
-        LASER_ORIGIN_Z,
-        localTargetRef.current.x,
-        localTargetRef.current.y,
-        localTargetRef.current.z,
-      ]);
+      const geometry = lineRef.current.geometry;
+      const instanceStart = geometry.getAttribute("instanceStart");
+      const instanceEnd = geometry.getAttribute("instanceEnd");
+
+      if (instanceStart && instanceEnd) {
+        instanceStart.setXYZ(0, 0, 0, LASER_ORIGIN_Z);
+        instanceEnd.setXYZ(
+          0,
+          localTargetRef.current.x,
+          localTargetRef.current.y,
+          localTargetRef.current.z,
+        );
+        instanceStart.needsUpdate = true;
+        instanceEnd.needsUpdate = true;
+      } else {
+        if (!laserPointBufferRef.current) {
+          laserPointBufferRef.current = new Float32Array(LASER_POINT_BUFFER_LENGTH);
+        }
+        const pointBuffer = laserPointBufferRef.current;
+        pointBuffer[0] = 0;
+        pointBuffer[1] = 0;
+        pointBuffer[2] = LASER_ORIGIN_Z;
+        pointBuffer[3] = localTargetRef.current.x;
+        pointBuffer[4] = localTargetRef.current.y;
+        pointBuffer[5] = localTargetRef.current.z;
+        geometry.setPositions(pointBuffer);
+      }
     }
 
     if (impactRef.current) {

--- a/src/components/gameScene/pools.test.ts
+++ b/src/components/gameScene/pools.test.ts
@@ -3,9 +3,12 @@ import {
   createAsteroidPool,
   createExplosionPool,
   activateQueuedAsteroids,
+  activateQueuedAsteroidsWithDelta,
   deactivateAsteroid,
+  deactivateAsteroidWithDelta,
   deactivateExplosion,
   spawnSplitterFragments,
+  spawnSplitterFragmentsWithDelta,
   countActiveItems,
   type PooledAsteroid,
 } from "./pools";
@@ -102,6 +105,20 @@ describe("Pools Utility Functions", () => {
       expect(countActiveItems(nextPool)).toBe(1);
       expect(nextPool[0].pos).toEqual([10, 0, 0]);
     });
+
+    it("should report how many asteroids were activated", () => {
+      const pool = createAsteroidPool(3);
+      pool[0].active = true;
+      const spawns = [
+        { pos: [10, 0, 0] as [number, number, number], type: "swarmer" as const },
+        { pos: [20, 0, 0] as [number, number, number], type: "tank" as const },
+      ];
+
+      const result = activateQueuedAsteroidsWithDelta(pool, spawns);
+
+      expect(result.activeDelta).toBe(2);
+      expect(countActiveItems(result.items)).toBe(3);
+    });
   });
 
   describe("deactivateAsteroid", () => {
@@ -120,6 +137,16 @@ describe("Pools Utility Functions", () => {
       const pool = createAsteroidPool(2);
       const nextPool = deactivateAsteroid(pool, "non-existent-id");
       expect(nextPool).toBe(pool);
+    });
+
+    it("should report a negative delta when deactivating an asteroid", () => {
+      const pool = createAsteroidPool(2);
+      pool[0].active = true;
+
+      const result = deactivateAsteroidWithDelta(pool, pool[0].id);
+
+      expect(result.activeDelta).toBe(-1);
+      expect(result.items[0].active).toBe(false);
     });
   });
 
@@ -148,6 +175,16 @@ describe("Pools Utility Functions", () => {
       const nextPool = spawnSplitterFragments(pool, pos);
       expect(countActiveItems(nextPool)).toBe(1); // Still only 1 active
       expect(nextPool[0].pos).not.toEqual([12, 10, 10]);
+    });
+
+    it("should report the number of spawned splitter fragments", () => {
+      const pool = createAsteroidPool(3);
+      pool[0].active = true;
+
+      const result = spawnSplitterFragmentsWithDelta(pool, [10, 10, 10]);
+
+      expect(result.activeDelta).toBe(2);
+      expect(countActiveItems(result.items)).toBe(3);
     });
   });
 

--- a/src/components/gameScene/pools.ts
+++ b/src/components/gameScene/pools.ts
@@ -15,6 +15,11 @@ export interface PooledExplosion {
   type: AsteroidType;
 }
 
+export interface PoolUpdate<T> {
+  items: T[];
+  activeDelta: number;
+}
+
 function getStoragePosition(): [number, number, number] {
   return [0, -1000, 0];
 }
@@ -48,13 +53,14 @@ export function deactivateExplosion(pool: PooledExplosion[], id: string): Pooled
   return nextPool;
 }
 
-export function activateQueuedAsteroids(
+export function activateQueuedAsteroidsWithDelta(
   pool: PooledAsteroid[],
   spawns: Array<{ pos: [number, number, number]; type: AsteroidType }>,
-): PooledAsteroid[] {
+): PoolUpdate<PooledAsteroid> {
   const nextPool = [...pool];
   let modified = false;
   let nextAvailableIdx = 0;
+  let activeDelta = 0;
 
   for (const spawn of spawns) {
     while (nextAvailableIdx < nextPool.length && nextPool[nextAvailableIdx].active) {
@@ -73,27 +79,45 @@ export function activateQueuedAsteroids(
       type: spawn.type,
     };
     modified = true;
+    activeDelta++;
     nextAvailableIdx++;
   }
 
-  return modified ? nextPool : pool;
+  return {
+    items: modified ? nextPool : pool,
+    activeDelta,
+  };
 }
 
-export function deactivateAsteroid(pool: PooledAsteroid[], id: string): PooledAsteroid[] {
+export function activateQueuedAsteroids(
+  pool: PooledAsteroid[],
+  spawns: Array<{ pos: [number, number, number]; type: AsteroidType }>,
+): PooledAsteroid[] {
+  return activateQueuedAsteroidsWithDelta(pool, spawns).items;
+}
+
+export function deactivateAsteroidWithDelta(
+  pool: PooledAsteroid[],
+  id: string,
+): PoolUpdate<PooledAsteroid> {
   const idx = pool.findIndex((asteroid) => asteroid.id === id);
   if (idx === -1 || !pool[idx].active) {
-    return pool;
+    return { items: pool, activeDelta: 0 };
   }
 
   const nextPool = [...pool];
   nextPool[idx] = { ...nextPool[idx], active: false };
-  return nextPool;
+  return { items: nextPool, activeDelta: -1 };
 }
 
-export function spawnSplitterFragments(
+export function deactivateAsteroid(pool: PooledAsteroid[], id: string): PooledAsteroid[] {
+  return deactivateAsteroidWithDelta(pool, id).items;
+}
+
+export function spawnSplitterFragmentsWithDelta(
   pool: PooledAsteroid[],
   pos: [number, number, number],
-): PooledAsteroid[] {
+): PoolUpdate<PooledAsteroid> {
   const nextPool = [...pool];
   const offset = 2.0;
   let splitsLeft = 2;
@@ -112,7 +136,17 @@ export function spawnSplitterFragments(
     }
   }
 
-  return spawnedCount > 0 ? nextPool : pool;
+  return {
+    items: spawnedCount > 0 ? nextPool : pool,
+    activeDelta: spawnedCount,
+  };
+}
+
+export function spawnSplitterFragments(
+  pool: PooledAsteroid[],
+  pos: [number, number, number],
+): PooledAsteroid[] {
+  return spawnSplitterFragmentsWithDelta(pool, pos).items;
 }
 
 export function countActiveItems<T extends { active: boolean }>(items: T[]): number {

--- a/src/components/gameScene/useAsteroidManager.ts
+++ b/src/components/gameScene/useAsteroidManager.ts
@@ -5,12 +5,11 @@ import useGameStore from "../../store/gameStore";
 import { AsteroidType, updateSpatialIndex } from "../../ecs/world";
 import { clearAsteroidSpawns, drainAsteroidSpawns } from "../../ecs/asteroidSpawnQueue";
 import {
-  activateQueuedAsteroids,
-  countActiveItems,
+  activateQueuedAsteroidsWithDelta,
   createAsteroidPool,
-  deactivateAsteroid,
+  deactivateAsteroidWithDelta,
   type PooledAsteroid,
-  spawnSplitterFragments,
+  spawnSplitterFragmentsWithDelta,
 } from "./pools";
 
 export interface AsteroidManagerOptions {
@@ -63,10 +62,13 @@ export function useAsteroidManager({
     const spawns = drainAsteroidSpawns();
     if (spawns.length > 0) {
       setAsteroidState((prev) => {
-        const nextItems = activateQueuedAsteroids(prev.items, spawns);
+        const { items: nextItems, activeDelta } = activateQueuedAsteroidsWithDelta(
+          prev.items,
+          spawns,
+        );
         // Optimization: Update store count immediately if changed
         if (nextItems !== prev.items) {
-          const nextCount = countActiveItems(nextItems);
+          const nextCount = prev.activeCount + activeDelta;
           setActiveAsteroids(nextCount);
           return { items: nextItems, activeCount: nextCount };
         }
@@ -84,13 +86,18 @@ export function useAsteroidManager({
       }
 
       setAsteroidState((prev) => {
-        let nextItems = deactivateAsteroid(prev.items, id);
+        const deactivateResult = deactivateAsteroidWithDelta(prev.items, id);
+        let nextItems = deactivateResult.items;
+        let activeDelta = deactivateResult.activeDelta;
+
         if (type === "splitter" && !isBaseHit) {
-          nextItems = spawnSplitterFragments(nextItems, pos);
+          const splitterResult = spawnSplitterFragmentsWithDelta(nextItems, pos);
+          nextItems = splitterResult.items;
+          activeDelta += splitterResult.activeDelta;
         }
 
         if (nextItems !== prev.items) {
-          const nextCount = countActiveItems(nextItems);
+          const nextCount = prev.activeCount + activeDelta;
           // Update active count in global store
           setActiveAsteroids(nextCount);
           return { items: nextItems, activeCount: nextCount };

--- a/src/ecs/world.test.ts
+++ b/src/ecs/world.test.ts
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import {
   ECS,
+  asteroidCells,
   asteroidQuery,
   countAsteroidsInRange,
   findNearestAsteroidInRange,
@@ -86,6 +87,17 @@ describe("asteroid spatial index", () => {
     const results = queryAsteroidsInRange(new THREE.Vector3(0, 0, 0), 20);
     const matches = results.filter((entity) => entity === asteroid);
     expect(matches).toHaveLength(1);
+  });
+
+  it("drops empty cells after asteroids move away", () => {
+    const asteroid = addAsteroid("a-7", new THREE.Vector3(0, 0, 0));
+
+    expect(asteroidCells.size).toBe(1);
+
+    asteroid.position!.set(250, 0, 0);
+    updateSpatialIndex();
+
+    expect(asteroidCells.size).toBe(1);
   });
 });
 

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -90,9 +90,11 @@ function visitAsteroidsInRange(
 }
 
 export function updateSpatialIndex() {
-  for (const arr of asteroidCells.values()) {
+  for (const [key, arr] of asteroidCells) {
     arr.length = 0;
+    asteroidCells.delete(key);
   }
+
   for (const entity of asteroidQuery.entities) {
     if (!entity.position) continue;
     const x = Math.floor(entity.position.x / CELL_SIZE);


### PR DESCRIPTION
## Summary

This PR tightens several runtime hot paths found during the performance review.

- Reuses laser beam position storage instead of allocating a fresh points array every targeted turret frame.
- Moves explosion particle animation into one parent frame loop per active explosion and shares fragment geometry.
- Tracks asteroid pool active-count deltas during spawn, deactivate, and splitter-fragment operations instead of rescanning the full pool after each change.
- Deletes empty spatial-index cells on each rebuild so long sessions do not accumulate historical buckets.

## Validation

- `npm test`
- `npm run check`
- `npm run build`
- Browser smoke at `http://127.0.0.1:5176/asteroid-defender/`: opened the app and started a defense run with no console errors.

Build notes: the existing `%VITE_SITE_URL%` env warnings and large vendor chunk warning still appear during production build.
