### PR TITLE
[codex] Improve game hot paths and add benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "vp lint",
     "check": "vp check",
     "test": "vp test",
+    "bench": "vp test bench",
     "test:watch": "vp test watch",
     "preview": "vp preview"
   },

--- a/src/components/Turret.tsx
+++ b/src/components/Turret.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useMemo } from "react";
+import { useRef, useMemo } from "react";
 import { useFrame } from "@react-three/fiber";
 import { Edges, Line } from "@react-three/drei";
 import * as THREE from "three";
@@ -36,7 +36,6 @@ interface TurretProps {
 
 export default function Turret({ id, position, rotation }: TurretProps) {
   const turretGroup = useRef<THREE.Group>(null);
-  const [hasTarget, setHasTarget] = useState(false);
   const [rotationX, rotationY, rotationZ] = rotation;
   const baseRotation = useMemo(
     () => new THREE.Euler(rotationX, rotationY, rotationZ),
@@ -55,11 +54,21 @@ export default function Turret({ id, position, rotation }: TurretProps) {
   const hologramRingRef = useRef<THREE.Mesh>(null);
   const hologramRingMaterialRef = useRef<THREE.MeshBasicMaterial>(null);
   const hologramReticleRef = useRef<THREE.Group>(null);
+  const targetEffectsRef = useRef<THREE.Group>(null);
   const laserPointBufferRef = useRef<Float32Array | null>(null);
 
   // Keep vectors around instead of full React states to avoid unneeded renders
   const localTargetRef = useRef(new THREE.Vector3());
   const currentTargetRef = useRef<GameEntity | null>(null);
+  const hasTargetRef = useRef(false);
+
+  const setTargetEffectsVisible = (visible: boolean) => {
+    if (hasTargetRef.current === visible) return;
+    hasTargetRef.current = visible;
+    if (targetEffectsRef.current) {
+      targetEffectsRef.current.visible = visible;
+    }
+  };
 
   useFrame((state, delta) => {
     if (!turretGroup.current) return;
@@ -67,7 +76,7 @@ export default function Turret({ id, position, rotation }: TurretProps) {
     if (useGameStore.getState().gameState !== "playing") {
       releaseTarget(currentTargetRef.current, id);
       currentTargetRef.current = null;
-      if (hasTarget) setHasTarget(false);
+      setTargetEffectsVisible(false);
       return;
     }
 
@@ -91,7 +100,7 @@ export default function Turret({ id, position, rotation }: TurretProps) {
 
       nearestEntity.targetedBy = id;
 
-      if (!hasTarget) setHasTarget(true);
+      setTargetEffectsVisible(true);
       recalibrationStartRef.current = null;
       if (barrelGroupRef.current) barrelGroupRef.current.rotation.set(0, 0, 0);
 
@@ -102,7 +111,7 @@ export default function Turret({ id, position, rotation }: TurretProps) {
         releaseTarget(currentTargetRef.current, id);
         currentTargetRef.current = null;
       }
-      if (hasTarget) setHasTarget(false);
+      setTargetEffectsVisible(false);
 
       applyIdleTurretRotation(
         turretGroup.current,
@@ -143,17 +152,19 @@ export default function Turret({ id, position, rotation }: TurretProps) {
 
     if (hologramRingRef.current) {
       hologramRingRef.current.rotation.z = (state.clock.elapsedTime * 1.2) % (Math.PI * 2);
-      const scale = hasTarget ? 1.05 + pulse * 0.2 : 0.95 + pulse * 0.08;
+      const scale = hasTargetRef.current ? 1.05 + pulse * 0.2 : 0.95 + pulse * 0.08;
       hologramRingRef.current.scale.setScalar(scale);
     }
     if (hologramRingMaterialRef.current) {
-      hologramRingMaterialRef.current.opacity = hasTarget ? 0.45 + pulse * 0.2 : 0.2 + pulse * 0.08;
+      hologramRingMaterialRef.current.opacity = hasTargetRef.current
+        ? 0.45 + pulse * 0.2
+        : 0.2 + pulse * 0.08;
     }
     if (hologramReticleRef.current) {
       hologramReticleRef.current.rotation.z = (-state.clock.elapsedTime * 1.6) % (Math.PI * 2);
     }
 
-    if (!hasTarget) return;
+    if (!hasTargetRef.current) return;
 
     const lineMaterial = lineRef.current?.material;
     if (lineMaterial instanceof LineMaterial) {
@@ -251,36 +262,34 @@ export default function Turret({ id, position, rotation }: TurretProps) {
         <Line points={HOLOGRAM_POINTS_Y} color="#7ec8ff" lineWidth={1} transparent opacity={0.45} />
       </group>
 
-      {hasTarget && (
-        <>
-          <Line
-            ref={lineRef}
-            points={INITIAL_LASER_POINTS} // Initialized coords, replaced in useFrame
-            color={LASER_COLOR}
-            lineWidth={3}
-          />
-          <mesh ref={impactRef} position={[0, 0, 0]}>
-            <sphereGeometry args={[0.6, 8, 8]} />
-            <meshBasicMaterial color={LASER_COLOR} toneMapped={false} transparent opacity={0.9} />
-          </mesh>
-          <pointLight
-            ref={beamLightRef}
-            position={[0, 0, 0]}
-            color="#ff4a4a"
-            intensity={5}
-            distance={14}
-            decay={2}
-          />
-          <pointLight
-            ref={impactLightRef}
-            position={[0, 0, 0]}
-            color="#ff7a5f"
-            intensity={7}
-            distance={10}
-            decay={2}
-          />
-        </>
-      )}
+      <group ref={targetEffectsRef} visible={false}>
+        <Line
+          ref={lineRef}
+          points={INITIAL_LASER_POINTS} // Initialized coords, replaced in useFrame
+          color={LASER_COLOR}
+          lineWidth={3}
+        />
+        <mesh ref={impactRef} position={[0, 0, 0]}>
+          <sphereGeometry args={[0.6, 8, 8]} />
+          <meshBasicMaterial color={LASER_COLOR} toneMapped={false} transparent opacity={0.9} />
+        </mesh>
+        <pointLight
+          ref={beamLightRef}
+          position={[0, 0, 0]}
+          color="#ff4a4a"
+          intensity={5}
+          distance={14}
+          decay={2}
+        />
+        <pointLight
+          ref={impactLightRef}
+          position={[0, 0, 0]}
+          color="#ff7a5f"
+          intensity={7}
+          distance={10}
+          decay={2}
+        />
+      </group>
     </group>
   );
 }

--- a/src/components/background/SpaceDust.tsx
+++ b/src/components/background/SpaceDust.tsx
@@ -24,6 +24,7 @@ interface SpaceDustProps {
 
 export default function SpaceDust({ count, animate }: SpaceDustProps) {
   const pointsRef = useRef<THREE.Points>(null);
+  const pendingDeltaRef = useRef(0);
   const { positions, velocities } = useMemo(() => createSpaceDustData(count), [count]);
 
   useEffect(() => {
@@ -37,11 +38,16 @@ export default function SpaceDust({ count, animate }: SpaceDustProps) {
 
   useFrame((_, delta) => {
     if (!pointsRef.current || !animate) return;
+    pendingDeltaRef.current += delta;
+    if (pendingDeltaRef.current < 1 / 30) return;
+
+    const stepDelta = pendingDeltaRef.current;
+    pendingDeltaRef.current = 0;
     const pos = pointsRef.current.geometry.attributes.position.array as Float32Array;
     for (let i = 0; i < count; i++) {
-      pos[i * 3] += velocities[i * 3] * delta;
-      pos[i * 3 + 1] += velocities[i * 3 + 1] * delta;
-      pos[i * 3 + 2] += velocities[i * 3 + 2] * delta;
+      pos[i * 3] += velocities[i * 3] * stepDelta;
+      pos[i * 3 + 1] += velocities[i * 3 + 1] * stepDelta;
+      pos[i * 3 + 2] += velocities[i * 3 + 2] * stepDelta;
       for (let j = 0; j < 3; j++) {
         if (pos[i * 3 + j] > 25) pos[i * 3 + j] = -25;
         if (pos[i * 3 + j] < -25) pos[i * 3 + j] = 25;

--- a/src/components/gameScene/pools.bench.ts
+++ b/src/components/gameScene/pools.bench.ts
@@ -1,0 +1,35 @@
+import { bench, describe } from "vite-plus/test";
+import {
+  activateQueuedAsteroidsWithDelta,
+  createAsteroidPool,
+  deactivateAsteroidWithDelta,
+  spawnSplitterFragmentsWithDelta,
+} from "./pools";
+
+const spawns = Array.from({ length: 10 }, (_, index) => ({
+  pos: [index, 0, 0] as [number, number, number],
+  type: index % 3 === 0 ? ("tank" as const) : ("swarmer" as const),
+}));
+
+describe("pool lifecycle hot paths", () => {
+  bench("activates queued asteroids in a 60-slot pool", () => {
+    const pool = createAsteroidPool(60);
+    activateQueuedAsteroidsWithDelta(pool, spawns);
+  });
+
+  bench("deactivates an active asteroid in a 60-slot pool", () => {
+    const pool = createAsteroidPool(60).map((asteroid, index) => ({
+      ...asteroid,
+      active: index < 30,
+    }));
+    deactivateAsteroidWithDelta(pool, pool[20].id);
+  });
+
+  bench("spawns splitter fragments into a partially occupied pool", () => {
+    const pool = createAsteroidPool(60).map((asteroid, index) => ({
+      ...asteroid,
+      active: index < 45,
+    }));
+    spawnSplitterFragmentsWithDelta(pool, [0, 0, 0]);
+  });
+});

--- a/src/components/gameScene/useAsteroidManager.ts
+++ b/src/components/gameScene/useAsteroidManager.ts
@@ -56,9 +56,9 @@ export function useAsteroidManager({
 
   // Update spatial index and process new spawns every frame
   useFrame(() => {
-    updateSpatialIndex();
     if (useGameStore.getState().gameState !== "playing") return;
 
+    updateSpatialIndex();
     const spawns = drainAsteroidSpawns();
     if (spawns.length > 0) {
       setAsteroidState((prev) => {

--- a/src/ecs/world.bench.ts
+++ b/src/ecs/world.bench.ts
@@ -1,0 +1,50 @@
+import * as THREE from "three";
+import { afterAll, beforeAll, bench, describe } from "vite-plus/test";
+import {
+  ECS,
+  asteroidQuery,
+  countAsteroidsInRange,
+  findNearestAsteroidInRange,
+  updateSpatialIndex,
+} from "./world";
+
+function clearWorld() {
+  for (const entity of Array.from(asteroidQuery)) {
+    ECS.remove(entity);
+  }
+  updateSpatialIndex();
+}
+
+function seedAsteroids(count: number) {
+  clearWorld();
+
+  for (let i = 0; i < count; i++) {
+    ECS.add({
+      id: `bench-${i}`,
+      isAsteroid: true,
+      position: new THREE.Vector3((i % 12) * 4 - 24, Math.floor(i / 12) * 3 - 12, i % 5),
+      health: 100,
+    });
+  }
+
+  updateSpatialIndex();
+}
+
+describe("spatial index hot paths", () => {
+  beforeAll(() => seedAsteroids(60));
+  afterAll(clearWorld);
+
+  bench("rebuilds the asteroid spatial index", () => {
+    updateSpatialIndex();
+  });
+
+  bench("counts nearby asteroids from indexed cells", () => {
+    countAsteroidsInRange(new THREE.Vector3(0, 0, 0), 25);
+  });
+
+  bench("finds nearest turret target with scoring", () => {
+    findNearestAsteroidInRange(new THREE.Vector3(5, 1, 0), 50, (entity, distSq) =>
+      entity.position && entity.position.y < 0 ? Infinity : distSq,
+    );
+  });
+});

--- a/src/ecs/world.test.ts
+++ b/src/ecs/world.test.ts
@@ -99,6 +99,16 @@ describe("asteroid spatial index", () => {
 
     expect(asteroidCells.size).toBe(1);
   });
+
+  it("reuses cell buckets across spatial index updates", () => {
+    const asteroid = addAsteroid("a-8", new THREE.Vector3(0, 0, 0));
+    const initialBucket = asteroidCells.values().next().value;
+
+    asteroid.position!.set(8, 2, 1);
+    updateSpatialIndex();
+
+    expect(asteroidCells.values().next().value).toBe(initialBucket);
+  });
 });
 
 describe("countAsteroidsInRange", () => {

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -28,6 +28,7 @@ export function getCellKey(x: number, y: number, z: number): number {
 }
 
 export const asteroidCells = new Map<number, GameEntity[]>();
+const recycledAsteroidCellBuckets: GameEntity[][] = [];
 
 interface CellBounds {
   minX: number;
@@ -93,6 +94,7 @@ export function updateSpatialIndex() {
   for (const [key, arr] of asteroidCells) {
     arr.length = 0;
     asteroidCells.delete(key);
+    recycledAsteroidCellBuckets.push(arr);
   }
 
   for (const entity of asteroidQuery.entities) {
@@ -103,7 +105,7 @@ export function updateSpatialIndex() {
     const key = getCellKey(x, y, z);
     let arr = asteroidCells.get(key);
     if (!arr) {
-      arr = [];
+      arr = recycledAsteroidCellBuckets.pop() ?? [];
       asteroidCells.set(key, arr);
     }
     arr.push(entity);


### PR DESCRIPTION
## Summary

This PR addresses the performance review findings in the gameplay hot paths. The spatial index now reuses cell bucket arrays during rebuilds instead of allocating replacement arrays every frame, and the asteroid manager skips spatial index rebuilds entirely while the game is not actively playing. Turret target effects stay mounted and are toggled imperatively, which avoids React mount/unmount churn for laser beams, impact meshes, and point lights when targets flicker. Animated space dust now batches position-buffer uploads to a 30 Hz cadence while preserving accumulated motion.

The PR also introduces a benchmark suite using the existing `vite-plus/test` benchmark runner. It covers spatial index rebuild/query/nearest-target work and the asteroid pool lifecycle operations that sit near the gameplay loop.

## Verification

- `npm run check`
- `npm test -- --run --reporter dot`
- `npm run build`
- `npm run bench -- --reporter verbose`

Notes: build still reports the existing `%VITE_SITE_URL%` env placeholder warning and large vendor chunk warnings. The benchmark runner also prints its upstream experimental-feature notice.
