### PR TITLE
perf: skip spatial index rebuilds below query threshold (issue 113)

### DIFF
--- a/src/components/gameScene/useAsteroidManager.ts
+++ b/src/components/gameScene/useAsteroidManager.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useFrame } from "@react-three/fiber";
 import useGameStore from "../../store/gameStore";
-import { AsteroidType, updateSpatialIndex } from "../../ecs/world";
+import { AsteroidType, updateSpatialIndex, SPATIAL_INDEX_THRESHOLD, asteroidQuery } from "../../ecs/world";
 import { clearAsteroidSpawns, drainAsteroidSpawns } from "../../ecs/asteroidSpawnQueue";
 import { markTelemetry } from "../../telemetry/runtime";
 import { usePoolStore } from "../../store/poolStore";
@@ -59,7 +59,11 @@ export function useAsteroidManager({
   useFrame(() => {
     if (useGameStore.getState().gameState !== "playing") return;
 
-    updateSpatialIndex();
+    // Only rebuild the spatial index when the asteroid count is high enough
+    // that queries will actually use it (linear scan is faster below threshold)
+    if (asteroidQuery.entities.length >= SPATIAL_INDEX_THRESHOLD) {
+      updateSpatialIndex();
+    }
     const spawns = drainAsteroidSpawns();
     if (spawns.length > 0) {
       markTelemetry("asteroids:drain-spawns", {

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -18,6 +18,10 @@ export const ECS = new World<GameEntity>();
 export const asteroidQuery = ECS.with("isAsteroid");
 export const CELL_SIZE = 25;
 
+// Threshold below which queries use linear scan instead of spatial index.
+// Must match the threshold used in visitAsteroidsInRange.
+export const SPATIAL_INDEX_THRESHOLD = 80;
+
 let anyAsteroidMoved = false;
 
 export function markAsteroidDirty() {


### PR DESCRIPTION
## Summary

Avoid paying for spatial-index maintenance when the live asteroid count is still below the threshold (80) where gameplay queries switch from linear scan to indexed lookup.

## Changes

- **src/ecs/world.ts**: Export SPATIAL_INDEX_THRESHOLD (80) as a named constant
- **src/components/gameScene/useAsteroidManager.ts**: Gate updateSpatialIndex() behind asteroidQuery.entities.length >= SPATIAL_INDEX_THRESHOLD

## Why

At the current pool cap of 60 asteroids, updateSpatialIndex() was being called every frame but visitAsteroidsInRange uses linear scan when entities.length < 80. The spatial index was being rebuilt but never consulted.

## Verification

- npm run bench -- src/ecs/world.bench.ts: PASS
- All 105 tests: PASS

Closes #113