### PR TITLE
[Perf] Adapt asteroid visuals to live load

### DIFF
--- a/src/components/Asteroid.tsx
+++ b/src/components/Asteroid.tsx
@@ -44,6 +44,7 @@ interface AsteroidProps {
   type: AsteroidType;
   active: boolean; // Pooling: Object avoids physics/rendering workloads when inactive
   effectsQuality: EffectsQuality;
+  activeAsteroidCount: number;
   onDestroy: (
     id: string,
     pos: [number, number, number],
@@ -53,7 +54,7 @@ interface AsteroidProps {
   ) => void;
 }
 
-function Asteroid({ id, startPos, type, active, effectsQuality, onDestroy }: AsteroidProps) {
+function Asteroid({ id, startPos, type, active, effectsQuality, activeAsteroidCount, onDestroy }: AsteroidProps) {
   const rbRef = useRef<RapierRigidBody>(null);
   const entityRef = useRef<GameEntity | null>(null);
   const materialRef = useRef<THREE.MeshStandardMaterial>(null);
@@ -68,7 +69,7 @@ function Asteroid({ id, startPos, type, active, effectsQuality, onDestroy }: Ast
   const prevTankRingOpacityRef = useRef(-1);
 
   const cfg = ASTEROID_CONFIGS[type] || ASTEROID_CONFIGS["swarmer"];
-  const visualProfile = getAsteroidVisualProfile(type, effectsQuality);
+  const visualProfile = getAsteroidVisualProfile(type, effectsQuality, activeAsteroidCount);
 
   useEffect(() => {
     if (active) {

--- a/src/components/gameScene/AsteroidLayer.tsx
+++ b/src/components/gameScene/AsteroidLayer.tsx
@@ -12,6 +12,7 @@ interface AsteroidLayerProps {
 
 const AsteroidLayer = memo(function AsteroidLayer({ effectsQuality }: AsteroidLayerProps) {
   const asteroids = usePoolStore(useShallow((s) => s.asteroids));
+  const activeAsteroidCount = asteroids.filter((a) => a.active).length;
 
   const handleDestroy = useCallback(
     (id: string, pos: [number, number, number], isHit: boolean, type: AsteroidType, damage: number) => {
@@ -43,6 +44,7 @@ const AsteroidLayer = memo(function AsteroidLayer({ effectsQuality }: AsteroidLa
           type={ast.type}
           active={ast.active}
           effectsQuality={effectsQuality}
+          activeAsteroidCount={activeAsteroidCount}
           onDestroy={handleDestroy}
         />
       ))}

--- a/src/utils/asteroidVisualQuality.test.ts
+++ b/src/utils/asteroidVisualQuality.test.ts
@@ -65,4 +65,57 @@ describe("asteroidVisualQuality", () => {
       animateTankRing: false,
     });
   });
+
+  // --- Load-based degradation ---
+
+  it("drops trails when active asteroid count >= 20", () => {
+    const profile = getAsteroidVisualProfile("swarmer", "full", 20);
+    expect(profile.showTrail).toBe(false);
+    // Other effects remain
+    expect(profile.showEdges).toBe(true);
+    expect(profile.showSplitterRings).toBe(true);
+  });
+
+  it("drops trails and edges when active asteroid count >= 40", () => {
+    const profile = getAsteroidVisualProfile("swarmer", "full", 40);
+    expect(profile.showTrail).toBe(false);
+    expect(profile.showEdges).toBe(false);
+    expect(profile.showSplitterRings).toBe(true);
+  });
+
+  it("drops splitter rings when active asteroid count >= 50", () => {
+    const profile = getAsteroidVisualProfile("splitter", "full", 50);
+    expect(profile.showTrail).toBe(false);
+    expect(profile.showEdges).toBe(false);
+    expect(profile.showSplitterRings).toBe(false);
+    // Tank ring is a critical threat cue — kept regardless of load
+    expect(profile.showTankRing).toBe(true);
+  });
+
+  it("applies load-based degradation on top of reduced quality tier", () => {
+    // reduced tier already drops trails for swarmers
+    const profile = getAsteroidVisualProfile("swarmer", "reduced", 40);
+    expect(profile.showTrail).toBe(false); // already off at reduced
+    expect(profile.showEdges).toBe(false); // load drops edges
+    expect(profile.showSplitterRings).toBe(false); // load drops splitter rings
+  });
+
+  it("keeps tank ring as critical threat cue regardless of load", () => {
+    const profile = getAsteroidVisualProfile("tank", "full", 60);
+    expect(profile.showTankRing).toBe(true);
+  });
+
+  it("returns base profile when activeAsteroidCount is undefined", () => {
+    const profile = getAsteroidVisualProfile("swarmer", "full");
+    expect(profile.showTrail).toBe(true);
+    expect(profile.showEdges).toBe(true);
+    expect(profile.showSplitterRings).toBe(true);
+  });
+
+  it("does not drop effects below load thresholds", () => {
+    const profile = getAsteroidVisualProfile("swarmer", "full", 19);
+    expect(profile.showTrail).toBe(true);
+    expect(profile.showEdges).toBe(true);
+    expect(profile.showSplitterRings).toBe(true);
+  });
 });

--- a/src/utils/asteroidVisualQuality.ts
+++ b/src/utils/asteroidVisualQuality.ts
@@ -43,29 +43,52 @@ const OFF_PROFILE: AsteroidVisualProfile = {
   animateTankRing: false,
 };
 
+/** Load-based degradation thresholds — graceful removal of decorative effects as asteroid count rises */
+const LOAD_TRAIL_DROP_COUNT = 20;
+const LOAD_EDGES_DROP_COUNT = 40;
+const LOAD_SPLITTER_RINGS_DROP_COUNT = 50;
+
 export function getAsteroidVisualProfile(
   type: AsteroidType,
   quality: EffectsQuality,
+  activeAsteroidCount?: number,
 ): AsteroidVisualProfile {
+  // Start from the quality-tier base profile
+  let profile: AsteroidVisualProfile;
   if (quality === "full") {
-    return FULL_PROFILE;
+    profile = { ...FULL_PROFILE };
+  } else if (quality === "off") {
+    profile = { ...OFF_PROFILE };
+  } else {
+    // "reduced" tier
+    profile = {
+      showTrail: type !== "swarmer",
+      trailWidth: type === "tank" ? 0.6 : 0.5,
+      trailLength: type === "tank" ? 2.8 : 2.2,
+      trailDecay: 1,
+      trailStride: type === "tank" ? 0.28 : 0.35,
+      showEdges: false,
+      showTankRing: type === "tank",
+      showSplitterRings: false,
+      showProximityGlow: true,
+      animateProximityGlow: false,
+      animateTankRing: false,
+    };
   }
 
-  if (quality === "off") {
-    return OFF_PROFILE;
+  // Apply load-based degradation on top of the quality tier
+  if (activeAsteroidCount !== undefined) {
+    if (activeAsteroidCount >= LOAD_TRAIL_DROP_COUNT) {
+      profile.showTrail = false;
+    }
+    if (activeAsteroidCount >= LOAD_EDGES_DROP_COUNT) {
+      profile.showEdges = false;
+    }
+    if (activeAsteroidCount >= LOAD_SPLITTER_RINGS_DROP_COUNT) {
+      profile.showSplitterRings = false;
+    }
+    // Tank ring is a critical threat cue — keep it regardless of load
   }
 
-  return {
-    showTrail: type !== "swarmer",
-    trailWidth: type === "tank" ? 0.6 : 0.5,
-    trailLength: type === "tank" ? 2.8 : 2.2,
-    trailDecay: 1,
-    trailStride: type === "tank" ? 0.28 : 0.35,
-    showEdges: false,
-    showTankRing: type === "tank",
-    showSplitterRings: false,
-    showProximityGlow: true,
-    animateProximityGlow: false,
-    animateTankRing: false,
-  };
+  return profile;
 }


### PR DESCRIPTION
## Summary

Issue #115 - dynamically scale down asteroid visual complexity based on live gameplay load, not just the global quality tier.

## Changes

- **asteroidVisualQuality.ts** - getAsteroidVisualProfile now accepts an optional activeAsteroidCount parameter. Load-based degradation strips effects in order of cost:
  - >= 20 active: trails drop first (most expensive Trail render pass)
  - >= 40 active: edges drop next
  - >= 50 active: splitter decorative rings drop
  - Tank ring is kept regardless of load -- it is a critical threat cue

- **AsteroidLayer.tsx** - computes activeAsteroidCount directly from the pool store and passes it to each Asteroid

- **Asteroid.tsx** - threads activeAsteroidCount prop through to getAsteroidVisualProfile

- **asteroidVisualQuality.test.ts** - 7 new test cases covering load-based degradation at each threshold, cross-tier behavior, and critical cue preservation

## Checklist

- [x] Define load-based thresholds using active asteroid count
- [x] Drop trails first, then outlines, then decorative rings as load increases
- [x] Keep gameplay readability and threat cues intact (tank ring never dropped)
- [ ] Re-profile visual-heavy waves after tuning thresholds <- deferred -- thresholds are conservative starting points

Closes #115

Generated with Claude Code