### PR TITLE
feat: use Rapier collision events for base damage detection (#129)

### DIFF
--- a/src/components/Asteroid.tsx
+++ b/src/components/Asteroid.tsx
@@ -30,6 +30,12 @@ import AsteroidVisual from "./asteroid/AsteroidVisual";
 import { activateAsteroidBody, deactivateAsteroidBody } from "./asteroid/bodyLifecycle";
 import { ASTEROID_CONFIGS } from "./asteroid/config";
 
+interface AsteroidUserData {
+  asteroidId?: string;
+  asteroidType?: AsteroidType;
+  asteroidDamage?: number;
+}
+
 const tempVec = new THREE.Vector3();
 
 // Threshold below which emissive/opacity writes are skipped to avoid material churn
@@ -95,6 +101,15 @@ function Asteroid({
       prevHealthRef.current = cfg.health;
       flashTimerRef.current = 0;
       isFirstActiveFrameRef.current = true;
+
+      // Tag the Rapier body so the Platform collision handler can identify this asteroid
+      if (rbRef.current) {
+        (rbRef.current.userData as AsteroidUserData) = {
+          asteroidId: id,
+          asteroidType: type,
+          asteroidDamage: cfg.damage,
+        };
+      }
     } else {
       // Un-pool into storage
       if (entityRef.current) {
@@ -105,6 +120,10 @@ function Asteroid({
       if (materialRef.current) {
         materialRef.current.emissive.setHex(0x000000);
         materialRef.current.emissiveIntensity = 0;
+      }
+      // Clear userData so deactivated bodies aren't mistaken for live asteroids
+      if (rbRef.current) {
+        (rbRef.current.userData as AsteroidUserData) = {};
       }
     }
 
@@ -157,7 +176,7 @@ function Asteroid({
 
     if (entityRef.current.health! <= 0) {
       const t = rbRef.current.translation();
-      onDestroy(id, [t.x, t.y, t.z], false, type, cfg.damage);
+      onDestroy(id, [t.x, t.y, t.z], entityRef.current.isBaseHit ?? false, type, cfg.damage);
       return;
     }
 
@@ -167,18 +186,11 @@ function Asteroid({
     entityRef.current.position!.set(translation.x, translation.y, translation.z);
     markAsteroidDirty();
 
-    // Move Asteroid towards the center platform (0,0,0)
+    // Compute distance from origin for proximity danger glow.
+    // Base-hit detection is now handled by Rapier collision events on the
+    // platform CylinderCollider (see Platform.tsx onCollisionEnter).
     tempVec.set(translation.x, translation.y, translation.z);
     const distSq = tempVec.lengthSq();
-    if (distSq <= 9) {
-      // Hit the platform
-      useGameStore.getState().takeDamage(cfg.damage);
-      onDestroy(id, [translation.x, translation.y, translation.z], true, type, cfg.damage);
-      return;
-    }
-
-    // Proximity danger glow: pulse emissive colour as asteroid closes in on the base.
-    // Quality scaling trims the more expensive animated material updates first.
     const dist = Math.sqrt(distSq);
     const imminentRatio = Math.max(0, 1 - dist / 35);
 

--- a/src/components/Platform.tsx
+++ b/src/components/Platform.tsx
@@ -1,9 +1,11 @@
 import { RigidBody, CylinderCollider } from "@react-three/rapier";
+import type { CollisionEnterPayload } from "@react-three/rapier";
 import { Edges } from "@react-three/drei";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useCallback } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import useGameStore from "../store/gameStore";
+import { asteroidQuery } from "../ecs/world";
 
 // Pre-allocated scratch colours to avoid per-frame GC pressure
 const _shieldHealthy = new THREE.Color("#7ec8ff");
@@ -76,6 +78,25 @@ export default function Platform({ shieldImpacts }: PlatformProps) {
   const shieldMaterialRef = useRef<THREE.MeshBasicMaterial>(null);
   const beaconGroupRef = useRef<THREE.Group>(null);
 
+  // Rapier collision handler: detect when an asteroid's BallCollider touches
+  // the platform's CylinderCollider. This replaces the per-frame distance
+  // check that was previously in Asteroid.tsx.
+  const onCollisionEnter = useCallback((payload: CollisionEnterPayload) => {
+    const ud = payload.other.rigidBody?.userData as { asteroidId?: string } | undefined;
+    if (!ud?.asteroidId) return;
+
+    // Find the ECS entity and mark it as a base hit
+    const entities = asteroidQuery.entities;
+    for (let i = 0; i < entities.length; i++) {
+      const entity = entities[i];
+      if (entity.id === ud.asteroidId && entity.health! > 0) {
+        entity.isBaseHit = true;
+        entity.health = 0;
+        return;
+      }
+    }
+  }, []);
+
   useFrame((state) => {
     const { health, maxHealth, reducedMotion } = useGameStore.getState();
     const ratio = maxHealth > 0 ? Math.max(0, health / maxHealth) : 1;
@@ -115,7 +136,7 @@ export default function Platform({ shieldImpacts }: PlatformProps) {
   });
 
   return (
-    <RigidBody type="fixed" colliders={false}>
+    <RigidBody type="fixed" colliders={false} onCollisionEnter={onCollisionEnter}>
       <CylinderCollider args={[1, 12]} />
       <group>
         <mesh receiveShadow>

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -11,6 +11,7 @@ export type GameEntity = {
   health?: number;
   targetedBy?: string | null;
   asteroidType?: AsteroidType;
+  isBaseHit?: boolean;
 };
 
 // Define the central ECS world


### PR DESCRIPTION
## Summary

Closes #129. Replaces the per-frame manual distance check (`distSq <= 9`) with Rapier's collision event system for base damage detection.

### Problem

The Asteroid component's `useFrame` ran a manual sphere-distance check every frame on every active asteroid. This was:
- **Physically inaccurate** — treated the base as a sphere of radius 3, ignoring the actual `CylinderCollider` shape
- **Per-frame overhead** — N distance checks per frame vs. event-driven (only fires when collisions actually occur)

### Solution

- Platform's `RigidBody` now has an `onCollisionEnter` callback that detects when an asteroid's `BallCollider` touches the platform's `CylinderCollider`
- Asteroids tag their Rapier bodies with `userData` (`{ asteroidId, asteroidType, asteroidDamage }`) for identification
- On collision, the handler sets `entity.isBaseHit = true` and `entity.health = 0`
- The asteroid's existing `useFrame` health-check passes the `isBaseHit` flag through to `onDestroy`

### Files changed

| File | Change |
|------|--------|
| `src/ecs/world.ts` | Added `isBaseHit?: boolean` to `GameEntity` |
| `src/components/Asteroid.tsx` | Set/clear `userData` on RigidBody; removed manual `distSq <= 9` check; wire `isBaseHit` into `onDestroy` |
| `src/components/Platform.tsx` | Added `onCollisionEnter` handler that marks ECS entities as base-hit |

### Benefits

- Uses actual collider shapes (cylinder + ball) instead of approximate sphere — more accurate
- Event-driven: only fires when collisions actually occur
- Fixes a double-damage bug: `takeDamage` was called both in `Asteroid.useFrame` and `AsteroidLayer.handleDestroy` for base hits — now called once

### Verification

- 11 test files, 91 tests pass
- All benchmarks pass (no regression)
- Lint/typecheck clean
