### PR TITLE
perf: start with lower visual quality and ramp up

### DIFF
--- a/src/utils/visualQuality.test.ts
+++ b/src/utils/visualQuality.test.ts
@@ -13,10 +13,10 @@ import {
 } from "./visualQuality";
 
 describe("visualQuality", () => {
-  it("starts with full effects on standard motion", () => {
+  it("starts with reduced effects on standard motion", () => {
     expect(getInitialVisualProfile(false)).toEqual({
-      effectsQuality: "full",
-      dpr: FULL_EFFECTS_MAX_DPR,
+      effectsQuality: "reduced",
+      dpr: REDUCED_EFFECTS_MAX_DPR,
     });
   });
 

--- a/src/utils/visualQuality.ts
+++ b/src/utils/visualQuality.ts
@@ -20,7 +20,7 @@ function normalizeEffectsQuality(quality: EffectsQuality, reducedMotion: boolean
 }
 
 export function getPreferredEffectsQuality(reducedMotion: boolean): EffectsQuality {
-  return reducedMotion ? "reduced" : "full";
+  return reducedMotion ? "reduced" : "reduced";
 }
 
 export function getMaxDprForEffectsQuality(


### PR DESCRIPTION
## Summary

Flip the startup visual-quality baseline to a lower, more conservative profile and let the existing PerformanceMonitor ramp up when the browser has headroom.

## What changed

- Default startup visual quality now begins in the reduced tier instead of full.
- `getPreferredEffectsQuality()` now favors the conservative baseline, which preserves the existing adaptive upgrade path.
- Added/updated tests to cover the new startup behavior.

## Verification

- `npm test -- --run` ✅
- `npm run lint` ✅ (existing warning only)
- `npm run check` ✅
- `npm run bench` ✅