### PR TITLE
perf(ecs): reduce hot-path allocations and improve index reuse

### DIFF
--- a/src/components/turret/helpers.ts
+++ b/src/components/turret/helpers.ts
@@ -13,12 +13,16 @@ export function releaseTarget(target: GameEntity | null, turretId: string) {
 }
 
 export function findTurretTarget(turret: THREE.Group, turretId: string): GameEntity | null {
-  const isTopTurret = turret.position.y > 0;
+  const turretPosition = turret.position;
+  const isTopTurret = turretPosition.y > 0;
 
-  return findNearestAsteroidInRange(turret.position, TURRET_RANGE, (entity, distSq) => {
-    if (!entity.position) return Infinity;
-    if (entity.position.y > 0 !== isTopTurret) return Infinity;
-    return distSq + (entity.targetedBy && entity.targetedBy !== turretId ? TARGETING_PENALTY : 0);
+  return findNearestAsteroidInRange(turretPosition, TURRET_RANGE, (entity, distSq) => {
+    const entityPosition = entity.position;
+    if (!entityPosition) return Infinity;
+    if (entityPosition.y > 0 !== isTopTurret) return Infinity;
+
+    const targetedBy = entity.targetedBy;
+    return distSq + (targetedBy && targetedBy !== turretId ? TARGETING_PENALTY : 0);
   });
 }
 

--- a/src/ecs/world.test.ts
+++ b/src/ecs/world.test.ts
@@ -6,6 +6,7 @@ import {
   asteroidQuery,
   countAsteroidsInRange,
   findNearestAsteroidInRange,
+  getCellKey,
   markAsteroidDirty,
   queryAsteroidsInRange,
   updateSpatialIndex,
@@ -101,6 +102,22 @@ describe("asteroid spatial index", () => {
     updateSpatialIndex();
 
     expect(asteroidCells.size).toBe(1);
+  });
+
+  it("reuses existing cell buckets across rebuilds", () => {
+    markAsteroidDirty();
+    const asteroid = addAsteroid("a-8", new THREE.Vector3(0, 0, 0));
+    const initialBucket = asteroidCells.get(getCellKey(0, 0, 0));
+
+    expect(initialBucket).toBeDefined();
+
+    asteroid.position!.set(1, 0, 0);
+    markAsteroidDirty();
+    updateSpatialIndex();
+
+    const rebuiltBucket = asteroidCells.get(getCellKey(0, 0, 0));
+
+    expect(rebuiltBucket).toBe(initialBucket);
   });
 
   it("correctly queries asteroids after spatial index updates", () => {

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -92,7 +92,7 @@ function visitAsteroidsInRange(
 
   // Performance optimization: For small numbers of active entities,
   // a linear scan is much faster than checking 125 spatial index cells.
-  if (entities.length < 80) {
+  if (entities.length < SPATIAL_INDEX_THRESHOLD) {
     for (let i = 0; i < entities.length; i++) {
       const entity = entities[i];
       if (entity.position) {
@@ -124,20 +124,45 @@ export function updateSpatialIndex() {
   if (!anyAsteroidMoved) return;
   anyAsteroidMoved = false;
 
-  asteroidCells.clear();
+  const entities = asteroidQuery.entities;
+  const usedKeys = new Set<number>();
 
-  for (const entity of asteroidQuery.entities) {
+  for (let i = 0; i < entities.length; i++) {
+    const entity = entities[i];
     if (!entity.position) continue;
+
     const x = Math.floor(entity.position.x / CELL_SIZE);
     const y = Math.floor(entity.position.y / CELL_SIZE);
     const z = Math.floor(entity.position.z / CELL_SIZE);
     const key = getCellKey(x, y, z);
-    let arr = asteroidCells.get(key);
-    if (!arr) {
-      arr = [];
-      asteroidCells.set(key, arr);
+
+    usedKeys.add(key);
+
+    let cell = asteroidCells.get(key);
+    if (!cell) {
+      cell = [];
+      asteroidCells.set(key, cell);
     }
-    arr.push(entity);
+
+    cell.length = 0;
+  }
+
+  for (let i = 0; i < entities.length; i++) {
+    const entity = entities[i];
+    if (!entity.position) continue;
+
+    const x = Math.floor(entity.position.x / CELL_SIZE);
+    const y = Math.floor(entity.position.y / CELL_SIZE);
+    const z = Math.floor(entity.position.z / CELL_SIZE);
+    const key = getCellKey(x, y, z);
+
+    asteroidCells.get(key)!.push(entity);
+  }
+
+  for (const key of asteroidCells.keys()) {
+    if (!usedKeys.has(key)) {
+      asteroidCells.delete(key);
+    }
   }
 }
 

--- a/src/store/poolStore.ts
+++ b/src/store/poolStore.ts
@@ -102,13 +102,11 @@ export const usePoolStore = create<PoolState>((set, get) => ({
 
         for (let s = 0; s < spawns.length; s++) {
           const idx = newFreeList.pop()!;
-          newAsteroids[idx] = {
-            ...newAsteroids[idx],
-            active: true,
-            pos: spawns[s].pos,
-            type: spawns[s].type,
-          };
-          newIdToIndex.set(newAsteroids[idx].id, idx);
+          const slot = newAsteroids[idx];
+          slot.active = true;
+          slot.pos = spawns[s].pos;
+          slot.type = spawns[s].type;
+          newIdToIndex.set(slot.id, idx);
         }
 
         markTelemetry("asteroids:activations", {
@@ -149,13 +147,11 @@ export const usePoolStore = create<PoolState>((set, get) => ({
       const toActivate = Math.min(spawns.length, newFreeList.length);
       for (let s = 0; s < toActivate; s++) {
         const idx = newFreeList.pop()!;
-        newAsteroids[idx] = {
-          ...newAsteroids[idx],
-          active: true,
-          pos: spawns[s].pos,
-          type: spawns[s].type,
-        };
-        newIdToIndex.set(newAsteroids[idx].id, idx);
+        const slot = newAsteroids[idx];
+        slot.active = true;
+        slot.pos = spawns[s].pos;
+        slot.type = spawns[s].type;
+        newIdToIndex.set(slot.id, idx);
       }
 
       markTelemetry("asteroids:activations", {
@@ -180,11 +176,9 @@ export const usePoolStore = create<PoolState>((set, get) => ({
 
     set((state) => {
       const newAsteroids = [...state.asteroids];
-      newAsteroids[idx] = {
-        ...newAsteroids[idx],
-        active: false,
-        pos: getStoragePosition(),
-      };
+      const slot = newAsteroids[idx];
+      slot.active = false;
+      slot.pos = getStoragePosition();
       const newFreeList = [...state.asteroidFreeList, idx];
       const newIdToIndex = new Map(state.asteroidIdToIndex);
       newIdToIndex.delete(id);
@@ -208,13 +202,11 @@ export const usePoolStore = create<PoolState>((set, get) => ({
         const newIdToIndex = new Map(state.explosionIdToIndex);
 
         const idx = newFreeList.pop()!;
-        newExplosions[idx] = {
-          ...newExplosions[idx],
-          active: true,
-          pos,
-          type,
-        };
-        newIdToIndex.set(newExplosions[idx].id, idx);
+        const slot = newExplosions[idx];
+        slot.active = true;
+        slot.pos = pos;
+        slot.type = type;
+        newIdToIndex.set(slot.id, idx);
 
         return {
           explosions: newExplosions,
@@ -237,13 +229,11 @@ export const usePoolStore = create<PoolState>((set, get) => ({
       const newIdToIndex = new Map(rebuilt.idToIndex);
 
       const idx = newFreeList.pop()!;
-      newExplosions[idx] = {
-        ...newExplosions[idx],
-        active: true,
-        pos,
-        type,
-      };
-      newIdToIndex.set(newExplosions[idx].id, idx);
+      const slot = newExplosions[idx];
+      slot.active = true;
+      slot.pos = pos;
+      slot.type = type;
+      newIdToIndex.set(slot.id, idx);
 
       return {
         explosions: newExplosions,
@@ -260,11 +250,9 @@ export const usePoolStore = create<PoolState>((set, get) => ({
 
     set((state) => {
       const newExplosions = [...state.explosions];
-      newExplosions[idx] = {
-        ...newExplosions[idx],
-        active: false,
-        pos: getStoragePosition(),
-      };
+      const slot = newExplosions[idx];
+      slot.active = false;
+      slot.pos = getStoragePosition();
       const newFreeList = [...state.explosionFreeList, idx];
       const newIdToIndex = new Map(state.explosionIdToIndex);
       newIdToIndex.delete(id);


### PR DESCRIPTION
## Summary

This PR tightens the three hot paths that were identified in the performance review:

1. spatial-index rebuild efficiency
2. turret query/scoring path
3. pool churn under burst-spawn conditions

## What changed

- Reused spatial-index cell buckets across rebuilds to reduce churn and improve locality.
- Replaced repeated object literal creation in the pool activation/deactivation path with in-place slot mutation to reduce allocations.
- Tightened the turret targeting scorer to avoid repeated property lookups and keep the hot callback cheaper.
- Added a regression test to cover spatial-index bucket reuse.

## Verification

- `npm test -- --run` ✅
- `npm run lint` ✅ (existing warning only)
- `npm run check` ✅
- `npm run bench` ✅
