### PR TITLE
perf(ecs): tighten query and targeting hot paths

### DIFF
--- a/src/components/Asteroid.tsx
+++ b/src/components/Asteroid.tsx
@@ -154,21 +154,23 @@ function Asteroid({
     }
     prevHealthRef.current = entityRef.current.health!;
 
+    const material = materialRef.current;
+
     if (flashTimerRef.current > 0) {
       flashTimerRef.current -= delta;
-      if (materialRef.current) {
-        materialRef.current.emissive.setHex(0xffffff);
+      if (material) {
+        material.emissive.setHex(0xffffff);
         const newIntensity = 2.0;
         if (Math.abs(newIntensity - prevEmissiveIntensityRef.current) > MATERIAL_WRITE_THRESHOLD) {
-          materialRef.current.emissiveIntensity = newIntensity;
+          material.emissiveIntensity = newIntensity;
           prevEmissiveIntensityRef.current = newIntensity;
         }
       }
-      if (flashTimerRef.current <= 0 && materialRef.current) {
-        materialRef.current.emissive.setHex(0x000000);
+      if (flashTimerRef.current <= 0 && material) {
+        material.emissive.setHex(0x000000);
         const newIntensity = 0;
         if (Math.abs(newIntensity - prevEmissiveIntensityRef.current) > MATERIAL_WRITE_THRESHOLD) {
-          materialRef.current.emissiveIntensity = newIntensity;
+          material.emissiveIntensity = newIntensity;
           prevEmissiveIntensityRef.current = newIntensity;
         }
       }
@@ -186,21 +188,34 @@ function Asteroid({
     entityRef.current.position!.set(translation.x, translation.y, translation.z);
     markAsteroidDirty();
 
-    // Compute distance from origin for proximity danger glow.
-    // Base-hit detection is now handled by Rapier collision events on the
-    // platform CylinderCollider (see Platform.tsx onCollisionEnter).
-    tempVec.set(translation.x, translation.y, translation.z);
-    const distSq = tempVec.lengthSq();
-    const dist = Math.sqrt(distSq);
-    const imminentRatio = Math.max(0, 1 - dist / 35);
+    const currentMaterial = materialRef.current;
+    const currentDangerRingMaterial = dangerRingMaterialRef.current;
+    const isTank = type === "tank";
+    const shouldUpdateGlow = flashTimerRef.current <= 0 && currentMaterial !== null;
+    const shouldUpdateTankRing = isTank && currentDangerRingMaterial !== null;
 
-    if (flashTimerRef.current <= 0 && materialRef.current) {
+    let imminentRatio = 0;
+    if (shouldUpdateGlow || shouldUpdateTankRing) {
+      // Base-hit detection is now handled by Rapier collision events on the
+      // platform CylinderCollider (see Platform.tsx onCollisionEnter).
+      tempVec.set(translation.x, translation.y, translation.z);
+      const distSq = tempVec.lengthSq();
+      const dist = Math.sqrt(distSq);
+      imminentRatio = Math.max(0, 1 - dist / 35);
+    }
+
+    if (shouldUpdateGlow) {
+      const material = currentMaterial;
+      if (!material) return;
+
       let newIntensity = 0;
-      if (visualProfile.showProximityGlow && imminentRatio > 0) {
+      const showProximityGlow = visualProfile.showProximityGlow;
+      const animateProximityGlow = visualProfile.animateProximityGlow;
+      if (showProximityGlow && imminentRatio > 0) {
         _proxColor.set(cfg.color);
-        materialRef.current.emissive.copy(_proxColor);
+        material.emissive.copy(_proxColor);
 
-        if (visualProfile.animateProximityGlow && !reducedMotion) {
+        if (animateProximityGlow && !reducedMotion) {
           const pulseSpeed = 3 + imminentRatio * 8;
           const pulseFactor = Math.sin(state.clock.elapsedTime * pulseSpeed) * 0.5 + 0.5;
           newIntensity = imminentRatio * 1.2 * pulseFactor;
@@ -208,20 +223,25 @@ function Asteroid({
           newIntensity = imminentRatio > 0.5 ? imminentRatio * 0.4 : 0;
         }
       } else {
-        materialRef.current.emissive.setHex(0x000000);
+        material.emissive.setHex(0x000000);
       }
       if (Math.abs(newIntensity - prevEmissiveIntensityRef.current) > MATERIAL_WRITE_THRESHOLD) {
-        materialRef.current.emissiveIntensity = newIntensity;
+        material.emissiveIntensity = newIntensity;
         prevEmissiveIntensityRef.current = newIntensity;
       }
     }
 
     // Tank-specific: pulse the outer danger ring opacity
-    if (type === "tank" && dangerRingMaterialRef.current) {
+    if (shouldUpdateTankRing) {
+      const dangerRingMaterial = currentDangerRingMaterial;
+      if (!dangerRingMaterial) return;
+
       let newOpacity = 0;
-      if (!visualProfile.showTankRing) {
+      const showTankRing = visualProfile.showTankRing;
+      const animateTankRing = visualProfile.animateTankRing;
+      if (!showTankRing) {
         newOpacity = 0;
-      } else if (visualProfile.animateTankRing && !reducedMotion) {
+      } else if (animateTankRing && !reducedMotion) {
         const ringPulse =
           Math.sin(state.clock.elapsedTime * (1.5 + imminentRatio * 3)) * 0.25 + 0.75;
         newOpacity = ringPulse * (0.25 + imminentRatio * 0.45);
@@ -229,7 +249,7 @@ function Asteroid({
         newOpacity = 0.3 + imminentRatio * 0.3;
       }
       if (Math.abs(newOpacity - prevTankRingOpacityRef.current) > MATERIAL_WRITE_THRESHOLD) {
-        dangerRingMaterialRef.current.opacity = newOpacity;
+        dangerRingMaterial.opacity = newOpacity;
         prevTankRingOpacityRef.current = newOpacity;
       }
     }

--- a/src/components/Asteroid.tsx
+++ b/src/components/Asteroid.tsx
@@ -36,8 +36,6 @@ interface AsteroidUserData {
   asteroidDamage?: number;
 }
 
-const tempVec = new THREE.Vector3();
-
 // Threshold below which emissive/opacity writes are skipped to avoid material churn
 const MATERIAL_WRITE_THRESHOLD = 0.01;
 
@@ -183,23 +181,26 @@ function Asteroid({
     }
 
     const translation = rbRef.current.translation();
+    const tx = translation.x;
+    const ty = translation.y;
+    const tz = translation.z;
 
     // Sync Rapier position to ECS for Turrets to read
-    entityRef.current.position!.set(translation.x, translation.y, translation.z);
+    entityRef.current.position!.set(tx, ty, tz);
     markAsteroidDirty();
 
     const currentMaterial = materialRef.current;
     const currentDangerRingMaterial = dangerRingMaterialRef.current;
-    const isTank = type === "tank";
-    const shouldUpdateGlow = flashTimerRef.current <= 0 && currentMaterial !== null;
-    const shouldUpdateTankRing = isTank && currentDangerRingMaterial !== null;
+    const shouldUpdateGlow =
+      flashTimerRef.current <= 0 && currentMaterial !== null && visualProfile.showProximityGlow;
+    const shouldUpdateTankRing =
+      type === "tank" && currentDangerRingMaterial !== null && visualProfile.showTankRing;
 
     let imminentRatio = 0;
     if (shouldUpdateGlow || shouldUpdateTankRing) {
       // Base-hit detection is now handled by Rapier collision events on the
       // platform CylinderCollider (see Platform.tsx onCollisionEnter).
-      tempVec.set(translation.x, translation.y, translation.z);
-      const distSq = tempVec.lengthSq();
+      const distSq = tx * tx + ty * ty + tz * tz;
       const dist = Math.sqrt(distSq);
       imminentRatio = Math.max(0, 1 - dist / 35);
     }
@@ -209,9 +210,8 @@ function Asteroid({
       if (!material) return;
 
       let newIntensity = 0;
-      const showProximityGlow = visualProfile.showProximityGlow;
       const animateProximityGlow = visualProfile.animateProximityGlow;
-      if (showProximityGlow && imminentRatio > 0) {
+      if (imminentRatio > 0) {
         _proxColor.set(cfg.color);
         material.emissive.copy(_proxColor);
 

--- a/src/components/AsteroidSpawner.tsx
+++ b/src/components/AsteroidSpawner.tsx
@@ -22,7 +22,7 @@ const SPAWN_RADIUS = 40;
 const PROXIMITY_THRESHOLD = 3;
 
 export default function AsteroidSpawner() {
-  const origin = new THREE.Vector3(0, 0, 0);
+  const originRef = useRef(new THREE.Vector3(0, 0, 0));
   const spawnTimer = useRef(0);
   const currentInterval = useRef(INITIAL_SPAWN_INTERVAL);
   const sessionId = useGameStore((state) => state.sessionId);
@@ -39,7 +39,7 @@ export default function AsteroidSpawner() {
     if (spawnTimer.current >= currentInterval.current) {
       spawnTimer.current = 0;
 
-      const closeCount = countAsteroidsInRange(origin, 25);
+      const closeCount = countAsteroidsInRange(originRef.current, 25);
 
       // Adjust spawn rate based on proximity count
       if (closeCount < PROXIMITY_THRESHOLD) {

--- a/src/components/Turret.tsx
+++ b/src/components/Turret.tsx
@@ -73,7 +73,8 @@ export default function Turret({ id, position, rotation }: TurretProps) {
       return;
     }
 
-    const nearestEntity: GameEntity | null = findTurretTarget(turretGroup.current, id);
+    const turret = turretGroup.current;
+    const nearestEntity: GameEntity | null = findTurretTarget(turret, id);
     let actualDist = 0;
 
     if (nearestEntity) {
@@ -83,12 +84,21 @@ export default function Turret({ id, position, rotation }: TurretProps) {
       }
       currentTargetRef.current = nearestEntity;
 
-      turretGroup.current.lookAt(nearestEntity.position!);
+      const targetPosition = nearestEntity.position;
+      if (!targetPosition) {
+        return;
+      }
+
+      turret.lookAt(targetPosition);
 
       // Optimized: Since we just called lookAt, the target's local position
       // is always (0, 0, actualDist). This avoids expensive matrix world
       // updates and worldToLocal inversions every frame.
-      const actualDistSq = turretGroup.current.position.distanceToSquared(nearestEntity.position!);
+      const turretPosition = turret.position;
+      const dx = turretPosition.x - targetPosition.x;
+      const dy = turretPosition.y - targetPosition.y;
+      const dz = turretPosition.z - targetPosition.z;
+      const actualDistSq = dx * dx + dy * dy + dz * dz;
       actualDist = Math.sqrt(actualDistSq);
       localTargetRef.current.set(0, 0, actualDist);
 

--- a/src/components/Turret.tsx
+++ b/src/components/Turret.tsx
@@ -148,27 +148,29 @@ export default function Turret({ id, position, rotation }: TurretProps) {
 
     // Pulse Animation for Laser & Impact
     pulseRef.current += delta * 30;
+    const elapsedTime = state.clock.elapsedTime;
     const pulse = Math.sin(pulseRef.current) * 0.5 + 0.5;
+    const isTargeting = hasTargetRef.current;
 
     if (coreMaterialRef.current) {
       coreMaterialRef.current.emissiveIntensity = 1.6 + pulse * 1.8;
     }
 
     if (hologramRingRef.current) {
-      hologramRingRef.current.rotation.z = (state.clock.elapsedTime * 1.2) % (Math.PI * 2);
-      const scale = hasTargetRef.current ? 1.05 + pulse * 0.2 : 0.95 + pulse * 0.08;
+      hologramRingRef.current.rotation.z = (elapsedTime * 1.2) % (Math.PI * 2);
+      const scale = isTargeting ? 1.05 + pulse * 0.2 : 0.95 + pulse * 0.08;
       hologramRingRef.current.scale.setScalar(scale);
     }
     if (hologramRingMaterialRef.current) {
-      hologramRingMaterialRef.current.opacity = hasTargetRef.current
+      hologramRingMaterialRef.current.opacity = isTargeting
         ? 0.45 + pulse * 0.2
         : 0.2 + pulse * 0.08;
     }
     if (hologramReticleRef.current) {
-      hologramReticleRef.current.rotation.z = (-state.clock.elapsedTime * 1.6) % (Math.PI * 2);
+      hologramReticleRef.current.rotation.z = (-elapsedTime * 1.6) % (Math.PI * 2);
     }
 
-    if (!hasTargetRef.current) return;
+    if (!isTargeting) return;
 
     if (laserMeshRef.current) {
       const length = actualDist - LASER_ORIGIN_Z;

--- a/src/components/turret/helpers.ts
+++ b/src/components/turret/helpers.ts
@@ -18,8 +18,13 @@ export function findTurretTarget(turret: THREE.Group, turretId: string): GameEnt
 
   return findNearestAsteroidInRange(turretPosition, TURRET_RANGE, (entity, distSq) => {
     const entityPosition = entity.position;
-    if (!entityPosition) return Infinity;
-    if (entityPosition.y > 0 !== isTopTurret) return Infinity;
+    if (!entityPosition) {
+      return Infinity;
+    }
+
+    if (entityPosition.y > 0 !== isTopTurret) {
+      return Infinity;
+    }
 
     const targetedBy = entity.targetedBy;
     return distSq + (targetedBy && targetedBy !== turretId ? TARGETING_PENALTY : 0);

--- a/src/components/turret/helpers.ts
+++ b/src/components/turret/helpers.ts
@@ -27,7 +27,8 @@ export function findTurretTarget(turret: THREE.Group, turretId: string): GameEnt
     }
 
     const targetedBy = entity.targetedBy;
-    return distSq + (targetedBy && targetedBy !== turretId ? TARGETING_PENALTY : 0);
+    const penalty = targetedBy && targetedBy !== turretId ? TARGETING_PENALTY : 0;
+    return distSq + penalty;
   });
 }
 

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -63,19 +63,16 @@ function getRangeCellBounds(position: THREE.Vector3, range: number): CellBounds 
   };
 }
 
-function squaredDistance(a: THREE.Vector3, b: THREE.Vector3): number {
-  const dx = a.x - b.x;
-  const dy = a.y - b.y;
-  const dz = a.z - b.z;
-  return dx * dx + dy * dy + dz * dz;
-}
-
 function visitAsteroidsInCell(
   cell: GameEntity[],
   position: THREE.Vector3,
   rangeSq: number,
   visitor: (entity: GameEntity, distSq: number) => void,
 ) {
+  const px = position.x;
+  const py = position.y;
+  const pz = position.z;
+
   for (let i = 0; i < cell.length; i++) {
     const entity = cell[i];
     const entityPosition = entity.position;
@@ -83,7 +80,11 @@ function visitAsteroidsInCell(
       continue;
     }
 
-    const distSq = squaredDistance(position, entityPosition);
+    const dx = px - entityPosition.x;
+    const dy = py - entityPosition.y;
+    const dz = pz - entityPosition.z;
+    const distSq = dx * dx + dy * dy + dz * dz;
+
     if (distSq <= rangeSq) {
       visitor(entity, distSq);
     }
@@ -97,6 +98,9 @@ function visitAsteroidsInRange(
 ) {
   const rangeSq = range * range;
   const entities = asteroidQuery.entities;
+  const px = position.x;
+  const py = position.y;
+  const pz = position.z;
 
   // Performance optimization: For small numbers of active entities,
   // a linear scan is much faster than checking 125 spatial index cells.
@@ -105,7 +109,11 @@ function visitAsteroidsInRange(
       const entity = entities[i];
       const entityPosition = entity.position;
       if (entityPosition) {
-        const distSq = squaredDistance(position, entityPosition);
+        const dx = px - entityPosition.x;
+        const dy = py - entityPosition.y;
+        const dz = pz - entityPosition.z;
+        const distSq = dx * dx + dy * dy + dz * dz;
+
         if (distSq <= rangeSq) {
           visitor(entity, distSq);
         }
@@ -134,44 +142,31 @@ export function updateSpatialIndex() {
   anyAsteroidMoved = false;
 
   const entities = asteroidQuery.entities;
-  const usedKeys = new Set<number>();
+  const bucketMap = new Map<number, GameEntity[]>();
 
   for (let i = 0; i < entities.length; i++) {
     const entity = entities[i];
-    if (!entity.position) continue;
+    const entityPosition = entity.position;
+    if (!entityPosition) continue;
 
-    const x = Math.floor(entity.position.x / CELL_SIZE);
-    const y = Math.floor(entity.position.y / CELL_SIZE);
-    const z = Math.floor(entity.position.z / CELL_SIZE);
+    const x = Math.floor(entityPosition.x / CELL_SIZE);
+    const y = Math.floor(entityPosition.y / CELL_SIZE);
+    const z = Math.floor(entityPosition.z / CELL_SIZE);
     const key = getCellKey(x, y, z);
 
-    usedKeys.add(key);
-
-    let cell = asteroidCells.get(key);
+    let cell = bucketMap.get(key);
     if (!cell) {
-      cell = [];
-      asteroidCells.set(key, cell);
+      cell = asteroidCells.get(key) ?? [];
+      cell.length = 0;
+      bucketMap.set(key, cell);
     }
 
-    cell.length = 0;
+    cell.push(entity);
   }
 
-  for (let i = 0; i < entities.length; i++) {
-    const entity = entities[i];
-    if (!entity.position) continue;
-
-    const x = Math.floor(entity.position.x / CELL_SIZE);
-    const y = Math.floor(entity.position.y / CELL_SIZE);
-    const z = Math.floor(entity.position.z / CELL_SIZE);
-    const key = getCellKey(x, y, z);
-
-    asteroidCells.get(key)!.push(entity);
-  }
-
-  for (const key of asteroidCells.keys()) {
-    if (!usedKeys.has(key)) {
-      asteroidCells.delete(key);
-    }
+  asteroidCells.clear();
+  for (const [key, cell] of bucketMap) {
+    asteroidCells.set(key, cell);
   }
 }
 

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -24,6 +24,15 @@ export const CELL_SIZE = 25;
 export const SPATIAL_INDEX_THRESHOLD = 80;
 
 let anyAsteroidMoved = false;
+const scratchCellBounds: CellBounds = {
+  minX: 0,
+  maxX: 0,
+  minY: 0,
+  maxY: 0,
+  minZ: 0,
+  maxZ: 0,
+};
+const rebuildBucketMap = new Map<number, GameEntity[]>();
 
 export function markAsteroidDirty() {
   anyAsteroidMoved = true;
@@ -52,15 +61,14 @@ interface CellBounds {
   maxZ: number;
 }
 
-function getRangeCellBounds(position: THREE.Vector3, range: number): CellBounds {
-  return {
-    minX: Math.floor((position.x - range) / CELL_SIZE),
-    maxX: Math.floor((position.x + range) / CELL_SIZE),
-    minY: Math.floor((position.y - range) / CELL_SIZE),
-    maxY: Math.floor((position.y + range) / CELL_SIZE),
-    minZ: Math.floor((position.z - range) / CELL_SIZE),
-    maxZ: Math.floor((position.z + range) / CELL_SIZE),
-  };
+function getRangeCellBounds(position: THREE.Vector3, range: number, out: CellBounds): CellBounds {
+  out.minX = Math.floor((position.x - range) / CELL_SIZE);
+  out.maxX = Math.floor((position.x + range) / CELL_SIZE);
+  out.minY = Math.floor((position.y - range) / CELL_SIZE);
+  out.maxY = Math.floor((position.y + range) / CELL_SIZE);
+  out.minZ = Math.floor((position.z - range) / CELL_SIZE);
+  out.maxZ = Math.floor((position.z + range) / CELL_SIZE);
+  return out;
 }
 
 function visitAsteroidsInCell(
@@ -122,7 +130,11 @@ function visitAsteroidsInRange(
     return;
   }
 
-  const { minX, maxX, minY, maxY, minZ, maxZ } = getRangeCellBounds(position, range);
+  const { minX, maxX, minY, maxY, minZ, maxZ } = getRangeCellBounds(
+    position,
+    range,
+    scratchCellBounds,
+  );
 
   for (let x = minX; x <= maxX; x++) {
     for (let y = minY; y <= maxY; y++) {
@@ -142,7 +154,7 @@ export function updateSpatialIndex() {
   anyAsteroidMoved = false;
 
   const entities = asteroidQuery.entities;
-  const bucketMap = new Map<number, GameEntity[]>();
+  rebuildBucketMap.clear();
 
   for (let i = 0; i < entities.length; i++) {
     const entity = entities[i];
@@ -154,18 +166,18 @@ export function updateSpatialIndex() {
     const z = Math.floor(entityPosition.z / CELL_SIZE);
     const key = getCellKey(x, y, z);
 
-    let cell = bucketMap.get(key);
+    let cell = rebuildBucketMap.get(key);
     if (!cell) {
       cell = asteroidCells.get(key) ?? [];
       cell.length = 0;
-      bucketMap.set(key, cell);
+      rebuildBucketMap.set(key, cell);
     }
 
     cell.push(entity);
   }
 
   asteroidCells.clear();
-  for (const [key, cell] of bucketMap) {
+  for (const [key, cell] of rebuildBucketMap) {
     asteroidCells.set(key, cell);
   }
 }

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -63,6 +63,13 @@ function getRangeCellBounds(position: THREE.Vector3, range: number): CellBounds 
   };
 }
 
+function squaredDistance(a: THREE.Vector3, b: THREE.Vector3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return dx * dx + dy * dy + dz * dz;
+}
+
 function visitAsteroidsInCell(
   cell: GameEntity[],
   position: THREE.Vector3,
@@ -71,11 +78,12 @@ function visitAsteroidsInCell(
 ) {
   for (let i = 0; i < cell.length; i++) {
     const entity = cell[i];
-    if (!entity.position) {
+    const entityPosition = entity.position;
+    if (!entityPosition) {
       continue;
     }
 
-    const distSq = position.distanceToSquared(entity.position);
+    const distSq = squaredDistance(position, entityPosition);
     if (distSq <= rangeSq) {
       visitor(entity, distSq);
     }
@@ -95,8 +103,9 @@ function visitAsteroidsInRange(
   if (entities.length < SPATIAL_INDEX_THRESHOLD) {
     for (let i = 0; i < entities.length; i++) {
       const entity = entities[i];
-      if (entity.position) {
-        const distSq = position.distanceToSquared(entity.position);
+      const entityPosition = entity.position;
+      if (entityPosition) {
+        const distSq = squaredDistance(position, entityPosition);
         if (distSq <= rangeSq) {
           visitor(entity, distSq);
         }


### PR DESCRIPTION
## Summary

This PR continues the hot-path performance pass by tightening the two highest-impact code paths:

1. ECS range-query / spatial-index traversal
2. Turret targeting score calculation

## What changed

- Replaced `Vector3.distanceToSquared()` with a cheaper local squared-distance helper in the ECS query hot path.
- Reduced callback overhead and made the turret-target score path more explicit and branch-friendly.
- Kept gameplay behavior unchanged while lowering the cost of the hottest per-frame query path.

## Verification

- `npm test -- --run` ✅
- `npm run lint` ✅ (existing warning only)
- `npm run check` ✅
- `npm run bench` ✅
