### PR TITLE
feat(balance): framerate-independent turret DPS and spawn churn tuning

### DIFF
--- a/docs/ARCHITECTURE/002-game-mechanics.md
+++ b/docs/ARCHITECTURE/002-game-mechanics.md
@@ -14,13 +14,13 @@ The origin `[0, 0, 0]` serves as the critical defense point. It is a static mesh
 
 ### 2. The Asteroid Swarm (Threats)
 
-- **Spawning System**: An asynchronous `<useFrame>` loop operating on a dynamic interval. It evaluates the "danger level" (how many asteroids are currently in close proximity via ECS queries) and adjusts its throttle accordingly.
+- **Spawning System**: An asynchronous `<useFrame>` loop operating on a dynamic interval between `1.0s` and `5.0s`. It evaluates the "danger level" (how many asteroids are currently in close proximity via ECS queries) and adjusts its throttle accordingly.
 - **Asteroid Classes**: Asteroids are assigned one of three classes on spawn, dictating their base stats:
   1. `swarmer`: Fast, low health, low damage.
   2. `tank`: Slow, very high health, massive damage on impact.
   3. `splitter`: Medium speed and health. Upon destruction by a turret, it shatters into multiple `swarmer` fragments.
 - **Movement**: Asteroids are spawned roughly along a 40-unit radius shell (with a slight vertical flattening to keep the swarm focused in the play area). Upon creation, their `<RigidBody>` is assigned a constant linear velocity directly towards the origin.
-- **Data Structure**: Asteroids write their position back into the ECS on every frame and manage their own `health` value (which can be fractional due to per-frame damage).
+- **Data Structure**: Asteroids write their position back into the ECS on every frame and manage their own `health` value (which can be fractional due to continuous DPS damage).
 
 ### 3. The Turret Defenses (Automata)
 
@@ -29,8 +29,8 @@ There are four turrets rigidly mounted to the top and bottom of the platform.
 - **AI Targeting**: Turrets operate their own `useFrame` logic, querying the spatial index grid (`queryAsteroidsInRange`) for nearby `isAsteroid=true` entities to avoid $O(N)$ full-world scans in hot loops.
 - **Hemispheric Restriction**: Turrets only evaluate asteroids in their respective hemisphere (Y > 0 or Y < 0) to prevent firing lasers "through" the platform hull.
 - **Target Distribution**: Turrets utilize collaborative targeting. They observe if an asteroid's `targetedBy` ECS field is populated by a _different_ Turret ID. If so, they artificially inflate the distance calculation to that asteroid, encouraging turrets spread their fire across multiple targets to maximize swarm suppression.
-- **Damage Model**: Damage scales linearly based on proximity. A laser deals maximum damage when an asteroid is near the hull, preventing instant-kills at spawn distance and allowing targets to visually close in on the base.
-- **Splitting Mechanics**: If a turret destroys an asteroid of the `splitter` class, the explosion callback explicitly spawns two new `swarmer` class asteroids near the impact site, forcing turrets to dynamically re-acquire the new targets.
+- **Damage Model**: Framerate-independent continuous Damage-Per-Second (DPS) scaling with `delta` (clamped to prevent hitch spikes). Base DPS scales linearly based on proximity (from `TURRET_MAX_DPS = 180` at point-blank to `TURRET_MIN_DPS = 10` at max range `TURRET_RANGE = 50`), preventing instant-kills at spawn distance and ensuring identical damage output across 60Hz, 120Hz, and 144Hz displays.
+- **Splitting Mechanics**: If a turret destroys an asteroid of the `splitter` class, the explosion callback explicitly enqueues two new `swarmer` class asteroids near the impact site, forcing turrets to dynamically re-acquire the new targets.
 
 ## Consequences
 

--- a/src/components/AsteroidSpawner.tsx
+++ b/src/components/AsteroidSpawner.tsx
@@ -15,7 +15,7 @@ function pickAsteroidType(): AsteroidType {
 }
 
 const INITIAL_SPAWN_INTERVAL = 2.0;
-const MIN_SPAWN_INTERVAL = 0.5;
+const MIN_SPAWN_INTERVAL = 1.0;
 const MAX_SPAWN_INTERVAL = 5.0;
 const SPAWN_ADJUSTMENT = 0.2;
 const SPAWN_RADIUS = 40;

--- a/src/components/Turret.tsx
+++ b/src/components/Turret.tsx
@@ -108,7 +108,7 @@ export default function Turret({ id, position, rotation }: TurretProps) {
       recalibrationStartRef.current = null;
       if (barrelGroupRef.current) barrelGroupRef.current.rotation.set(0, 0, 0);
 
-      nearestEntity.health! -= calculateTurretDamage(actualDistSq);
+      nearestEntity.health! -= calculateTurretDamage(actualDistSq, delta);
     } else {
       // Clear our lock if no target
       if (currentTargetRef.current) {

--- a/src/components/turret/helpers.test.ts
+++ b/src/components/turret/helpers.test.ts
@@ -3,10 +3,14 @@ import { describe, expect, it, beforeEach, afterEach } from "vite-plus/test";
 import { ECS, asteroidQuery, updateSpatialIndex, type GameEntity } from "../../ecs/world";
 import {
   releaseTarget,
+  calculateTurretDps,
   calculateTurretDamage,
   findTurretTarget,
   TURRET_RANGE,
   TARGETING_PENALTY,
+  TURRET_MAX_DPS,
+  TURRET_MIN_DPS,
+  MAX_DELTA_CLAMP,
 } from "./helpers";
 
 function clearWorld() {
@@ -59,18 +63,45 @@ describe("Turret Helpers", () => {
     });
   });
 
-  describe("calculateTurretDamage", () => {
-    it("should return max damage (5.0) at distance 0", () => {
-      expect(calculateTurretDamage(0)).toBeCloseTo(5.0);
+  describe("calculateTurretDps", () => {
+    it("should calculate max DPS at distance 0", () => {
+      expect(calculateTurretDps(0)).toBeCloseTo(TURRET_MAX_DPS);
     });
 
-    it("should return min damage (0.1) at max range", () => {
-      expect(calculateTurretDamage(TURRET_RANGE * TURRET_RANGE)).toBeCloseTo(0.1);
+    it("should calculate min DPS at max range", () => {
+      expect(calculateTurretDps(TURRET_RANGE * TURRET_RANGE)).toBeCloseTo(TURRET_MIN_DPS);
     });
 
-    it("should return intermediate damage correctly (midpoint)", () => {
+    it("should calculate intermediate DPS correctly (midpoint)", () => {
       const midDistSq = (TURRET_RANGE * TURRET_RANGE) / 2;
-      expect(calculateTurretDamage(midDistSq)).toBeCloseTo((5.0 + 0.1) / 2);
+      const expectedDps = (TURRET_MAX_DPS + TURRET_MIN_DPS) / 2;
+      expect(calculateTurretDps(midDistSq)).toBeCloseTo(expectedDps);
+    });
+  });
+
+  describe("calculateTurretDamage", () => {
+    it("should scale damage with delta per frame", () => {
+      const dt60 = 1 / 60;
+      const dt120 = 1 / 120;
+      const damageAt60 = calculateTurretDamage(0, dt60);
+      const damageAt120 = calculateTurretDamage(0, dt120);
+
+      expect(damageAt60).toBeCloseTo(TURRET_MAX_DPS * dt60);
+      expect(damageAt120).toBeCloseTo(TURRET_MAX_DPS * dt120);
+      expect(damageAt60).toBeCloseTo(damageAt120 * 2);
+    });
+
+    it("should default delta to 1/60s when omitted", () => {
+      expect(calculateTurretDamage(0)).toBeCloseTo(TURRET_MAX_DPS * (1 / 60));
+    });
+
+    it("should clamp large delta spikes to MAX_DELTA_CLAMP", () => {
+      const hugeDelta = 2.0;
+      expect(calculateTurretDamage(0, hugeDelta)).toBeCloseTo(TURRET_MAX_DPS * MAX_DELTA_CLAMP);
+    });
+
+    it("should clamp negative delta to 0", () => {
+      expect(calculateTurretDamage(0, -1)).toBe(0);
     });
   });
 

--- a/src/components/turret/helpers.ts
+++ b/src/components/turret/helpers.ts
@@ -46,8 +46,15 @@ export function applyIdleTurretRotation(
   );
 }
 
-export function calculateTurretDamage(actualDistSq: number) {
-  const maxDamage = 5;
-  const minDamage = 0.1;
-  return maxDamage - (actualDistSq / TURRET_RANGE_SQ) * (maxDamage - minDamage);
+export const TURRET_MAX_DPS = 180;
+export const TURRET_MIN_DPS = 10;
+export const MAX_DELTA_CLAMP = 0.1;
+
+export function calculateTurretDps(actualDistSq: number): number {
+  return TURRET_MAX_DPS - (actualDistSq / TURRET_RANGE_SQ) * (TURRET_MAX_DPS - TURRET_MIN_DPS);
+}
+
+export function calculateTurretDamage(actualDistSq: number, delta: number = 1 / 60): number {
+  const clampedDelta = Math.min(Math.max(delta, 0), MAX_DELTA_CLAMP);
+  return calculateTurretDps(actualDistSq) * clampedDelta;
 }


### PR DESCRIPTION
## Summary
Closes #142

### Changes
1. **Framerate-Independent Turret Damage**:
   - Updated `calculateTurretDamage` in `src/components/turret/helpers.ts` to accept `delta` and scale DPS continuously.
   - Guarded `delta` against background-tab hitches / frame drops via `MAX_DELTA_CLAMP = 0.1`.
   - Exported `calculateTurretDps`, `TURRET_MAX_DPS` (180), and `TURRET_MIN_DPS` (10).
   - Passed frame `delta` from `Turret.useFrame` to `calculateTurretDamage`.
2. **Spawn Churn Reduction**:
   - Raised `MIN_SPAWN_INTERVAL` in `src/components/AsteroidSpawner.tsx` from `0.5s` to `1.0s` (maximum 60 spawns/min down from 120 spawns/min).
3. **Docs & Verification**:
   - Updated ADR `docs/ARCHITECTURE/002-game-mechanics.md` with the DPS model and spawn throttle.
   - Added unit tests in `src/components/turret/helpers.test.ts` verifying DPS scaling, delta scaling, and clamp behaviors.
   - Verified format/lint (`npm run check`), type checking (`tsc --noEmit`), unit tests (`npm run test`), and build (`npm run build`).